### PR TITLE
fix link to Expiration example in Java

### DIFF
--- a/content/developer-guide/expiry.dita
+++ b/content/developer-guide/expiry.dita
@@ -7,7 +7,7 @@
 		or temporary documents representing a given process ownership. You can use expiration
 		values on documents to handle transient data.</shortdesc>
  <conbody>
-  
+
         <p>In databases without a built-in expiration feature, dealing with transient data may be
 			cumbersome. To provide “expiration” semantics, applications are forced to record a time
 			stamp in a record, and then upon each access of the record, check the time stamp, and if
@@ -47,7 +47,7 @@
                     format="html" scope="external">C</xref> | <xref
                     href="https://github.com/couchbaselabs/devguide-examples/blob/master/python/expiration.py"
                     format="html" scope="external">Python</xref> | <xref
-                    href="https://github.com/couchbaselabs/devguide-examples/blob/master/java/src/main/java/com/couchbase/devguide/expiration.java"
+                    href="https://github.com/couchbaselabs/devguide-examples/blob/master/java/src/main/java/com/couchbase/devguide/Expiration.java"
                     format="html" scope="external">Java</xref> | .NET | <xref
                     href="https://github.com/couchbaselabs/devguide-examples/blob/master/go/expiration.go"
                     format="html" scope="external">Go</xref> | <xref


### PR DESCRIPTION
Link was a placeholder not following Java naming convention.