### PR TITLE
added a table with URLs for downloading the packages for Mac, Windows, and Linux

### DIFF
--- a/content/developer-guide/query-workbench-intro.dita
+++ b/content/developer-guide/query-workbench-intro.dita
@@ -25,7 +25,7 @@
    <p><ol>
     <li>Download the query workbench archive file
                 <codeph>couchbase-query-workbench_dp1-&lt;<varname>os</varname>&gt;</codeph> by
-            choosing the appropriate package<p>
+            choosing the appropriate package:<p>
               <table>
                 <tgroup cols="2">
                   <colspec colnum="1" colname="c1" colwidth="1*"/>

--- a/content/developer-guide/query-workbench-intro.dita
+++ b/content/developer-guide/query-workbench-intro.dita
@@ -24,9 +24,39 @@
   <section><title>Installing the query workbench</title>
    <p><ol>
     <li>Download the query workbench archive file
-                <codeph>couchbase-query-workbench_dp1-&lt;<varname>os</varname>&gt;</codeph> from
-      <xref href="http://factory.hq.couchbase.com/cgi/s3.cgi?dir=s3://packages.couchbase.com/releases/query-workbench/dp1/" format="html"
-              scope="external">here</xref>. </li>
+                <codeph>couchbase-query-workbench_dp1-&lt;<varname>os</varname>&gt;</codeph> by
+            choosing the appropriate package<p>
+              <table>
+                <tgroup cols="2">
+                  <colspec colnum="1" colname="c1" colwidth="1*"/>
+                  <colspec colnum="2" colname="c2" colwidth="5*"/>
+                  <thead>
+                    <row>
+                      <entry>Platform</entry>
+                      <entry>Repository</entry>
+                    </row>
+                  </thead>
+                  <tbody>
+                    <row>
+                      <entry>Linux_x86_641 (md5)</entry>
+                      <entry><codeph>http://packages.couchbase.com/releases/query-workbench/dp1/couchbase-query-workbench_dp1.0.1-linux_x86_64.tar.gz</codeph></entry>
+                    </row>
+                    <row>
+                      <entry>MacOS_x86_644 (md5)</entry>
+                      <entry><codeph>http://packages.couchbase.com/releases/query-workbench/dp1/couchbase-query-workbench_dp1.0.1-macos_x86_64.tar.gz</codeph></entry>
+                    </row>
+                    <row>
+                      <entry>Windows_amd64 (md5)</entry>
+                      <entry><codeph>http://packages.couchbase.com/releases/query-workbench/dp1/couchbase-query-workbench_dp1.0.1-windows_amd64.zip</codeph></entry>
+                    </row>
+                    <row>
+                      <entry>Windows_x861 (md5)</entry>
+                      <entry><codeph>http://packages.couchbase.com/releases/query-workbench/dp1/couchbase-query-workbench_dp1.0.1-windows_x86.zip</codeph></entry>
+                    </row>
+                  </tbody>
+                </tgroup>
+              </table>
+            </p></li>
     <li>Extract the query workbench archive. The necessary files are contained in an inner folder,
               <filepath>couchbase-query-workbench</filepath>, which may be optionally copied
             elsewhere. </li>


### PR DESCRIPTION
These URLs replaced the link to the Factory, which was disabled for security reasons.