### PR TITLE
Release Notes for Java SDK 2.1.6

### DIFF
--- a/content/sdks/java-2.1/download-links.dita
+++ b/content/sdks/java-2.1/download-links.dita
@@ -7,9 +7,9 @@
 		API reference is also available online.</shortdesc>
 
 	<conbody>
-		
+
 		<section>
-			<title>Current Release (2.1.5)</title>
+			<title>Current Release (2.1.6)</title>
 			<p>To use the Java SDK, point your application project object model (POM) to the library, which
 				is available on Maven Central. Here is a typical <filepath>pom.xml</filepath> that you
 				can copy and paste into your Java project:</p>
@@ -17,18 +17,23 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>java-client</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
     </dependency>
 </dependencies>
 ]]></codeblock>
 
 			<ul>
-				<li>2.1.5
+				<li>2.1.6
 					<msgph outputclass="stable">GA</msgph>
 					<msgph outputclass="current">CURRENT</msgph>
+					- <xref href="http://packages.couchbase.com/clients/java/2.1.6/Couchbase-Java-Client-2.1.6.zip" format="html" scope="external">Download</xref>
+					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-java-client-2.1.6/" format="html" scope="external">API Reference</xref>
+				</li>
+				<li>2.1.5
+					<msgph outputclass="stable">GA</msgph>
 					- <xref href="http://packages.couchbase.com/clients/java/2.1.5/Couchbase-Java-Client-2.1.5.zip" format="html" scope="external">Download</xref>
 					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-java-client-2.1.5/" format="html" scope="external">API Reference</xref></li>
-					<li>2.1.4
+				<li>2.1.4
 					<msgph outputclass="stable">GA</msgph>
 					- <xref href="http://packages.couchbase.com/clients/java/2.1.4/Couchbase-Java-Client-2.1.4.zip" format="html" scope="external">Download</xref>
 					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-java-client-2.1.4/" format="html" scope="external">API Reference</xref></li>
@@ -72,6 +77,6 @@
 			<p>The current version in the 1.x release series is <codeph>1.4.10</codeph>. We strongly recommend
 				running this version to benefit from all the latest bug fixes.</p>
 		</section>
-		
+
 	</conbody>
 </concept>

--- a/content/sdks/java-2.1/getting-started.dita
+++ b/content/sdks/java-2.1/getting-started.dita
@@ -21,7 +21,7 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>java-client</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
     </dependency>
 </dependencies>
 ]]></codeblock>

--- a/content/sdks/java-2.1/migrate.dita
+++ b/content/sdks/java-2.1/migrate.dita
@@ -60,7 +60,7 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>java-client</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
     </dependency>
 </dependencies>
 ]]></codeblock>

--- a/content/sdks/java-2.1/release-notes.dita
+++ b/content/sdks/java-2.1/release-notes.dita
@@ -4,10 +4,41 @@
 	<title>Release notes</title>
 	<shortdesc>Release notes for the 2.1 version of the Java SDK.</shortdesc>
 
+	<concept id="ga216">
+		<title>Couchbase Java Client 2.1.6 GA (2 December 2015)</title>
+		<shortdesc>Version 2.1.6 is the sixth bug fix release of the 2.1 series.
+			It contains bug fixes and stability improvements in bootstrapping, configuration management, view queries and remove with CAS.</shortdesc>
+		<conbody>
+
+			<section id="ga216-fixes">
+				<title>Fixed issues</title>
+				<p>This release fixes the following issues:</p>
+
+				<ul>
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-864" format="html" scope="external">
+						JCBC-864</xref>: The remove operation, when used with the durability requirements now properly honors the CAS when provided inside the <codeph>Document</codeph>. It now correctly throws <codeph>CASMismatchExceptions</codeph> when the CAS does not match with the server. Previously, the supplied CAS was ignored and the remove operation perfomed without optimistic concurrency checks.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-263" format="html" scope="external">
+						JVMCBC-263</xref>: A bug in the view query parser has been uncovered which would make it hang when the key in particular includes a closing <codeph>}</codeph>, but no opening <codeph>{</codeph> inside a string.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-262" format="html" scope="external">
+						JVMCBC-262</xref>: The logic which performs proactive load of new configurations through the "Carrier Publication" mechanism now only targets nodes where the KV-Service is enabled. This is important in MDS scenarios so that it doesn't ask nodes where only the query and/or indexing services are enabled.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-102" format="html" scope="external">
+						JVMCBC-102</xref>: The initial bootstrap process has been made more resilient to individual node failures, fixing a bunch of bugs around initial bootstrapping. Especially the case where one of the nodes is not responding and opening a <codeph>memcached</codeph> type bucket now works correctly (this involves internally skipping over not responding nodes as well as falling back from carrier publication to the http bootstrapping approach).</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-257" format="html" scope="external">
+						JVMCBC-257</xref>, <xref href="https://www.couchbase.com/issues/browse/JVMCBC-265" format="html" scope="external">JVMCBC-265</xref>: The configuration management logic has been improved in various places, making it more resilient to failed bucket open attempts (cleaning up the state properly) as well as optimizing the proactive config loading approach when no bucktes are open or are currently being closed. In particular, one issue has been resolved where an asynchronous open bucket attempt with a fallback to a good one did not work previously.</li>
+				</ul>
+			</section>
+
+		</conbody>
+	</concept>
+
 	<concept id="ga215">
 		<title>Couchbase Java Client 2.1.5 GA (13 October 2015)</title>
 		<shortdesc>Version 2.1.5 is the fifth bug fix release of the 2.1 series. It contains bug
-			fixes and correctness improvements, especially during bootstrap, shutdown and when 
+			fixes and correctness improvements, especially during bootstrap, shutdown and when
 			SSL is enabled.</shortdesc>
 		<conbody>
 

--- a/content/sdks/java-2.1/tutorial.dita
+++ b/content/sdks/java-2.1/tutorial.dita
@@ -173,7 +173,7 @@ java -jar beersample-java2.jar]]></codeblock>
 		<dependency>
 			<groupId>com.couchbase.client</groupId>
 			<artifactId>java-client</artifactId>
-			<version>2.1.5</version>
+			<version>2.1.6</version>
 
 		</dependency>
 	</dependencies>

--- a/content/sdks/java-2.2/release-notes.dita
+++ b/content/sdks/java-2.2/release-notes.dita
@@ -11,7 +11,7 @@
 				<p>Version 2.2.2 is the second bug fix release of the 2.2 series. It brings many
 					bug fixes, stability improvements as well as smaller enhancements.</p>
 			</section>
-      		
+
       		<section id="ga222-features">
 				<title>New features and behavioral changes</title>
 				<p>This release contains the following enhancements:</p>
@@ -33,7 +33,7 @@
 				<ul>
 					<li>RxJava has been upgraded to 1.0.15 to address shutdown-cleanup related issues. In-depth discussion of this topic can be read <xref href="https://github.com/ReactiveX/RxJava/pull/3149" format="html" scope="external">here</xref>.</li>
 
-					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-864" format="html" scope="external">JCBC-864</xref>: The remove operation, when used with the durability requirements now properly honors the CAS when provided inside the <codeph>Document</codeph>. It now correctly throws <codeph>CASMismatchExceptions</codeph> when the CAS does not mismatch with the server. Previously, the supplied CAS was ignored and the remove operation perfomed without optimistic concurrency checks.</li>
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-864" format="html" scope="external">JCBC-864</xref>: The remove operation, when used with the durability requirements now properly honors the CAS when provided inside the <codeph>Document</codeph>. It now correctly throws <codeph>CASMismatchExceptions</codeph> when the CAS does not match with the server. Previously, the supplied CAS was ignored and the remove operation perfomed without optimistic concurrency checks.</li>
 
 					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-263" format="html" scope="external">JVMCBC-263</xref>: A bug in the view query parser has been uncovered which would make it hang when the key in particular includes a closing <codeph>}</codeph>, but no opening <codeph>{</codeph> inside a string.</li>
 
@@ -52,7 +52,7 @@
 			<section>
 				<title>Couchbase Java Client 2.2.1 GA (13 October 2015)</title>
 				<p>Version 2.2.1 is the first bug fix release of the 2.2 series. It contains bug
-					fixes and correctness improvements, especially during bootstrap, shutdown and when 
+					fixes and correctness improvements, especially during bootstrap, shutdown and when
 					SSL is enabled.</p>
 			</section>
 
@@ -179,7 +179,7 @@ public JsonDocument newDocument(String id, int expiry, JsonObject content, long 
 
 <section>
 	<title>New features and behavioral changes</title>
-		
+
 			<p>This release brings the following features and enhancements:</p>
 
 
@@ -330,7 +330,7 @@ System.out.println(repository.get("daschl", User.class).content().firstname);]]>
 
 		</section>
 
-		
+
 
 	</conbody>
 </concept>


### PR DESCRIPTION
This change is for 2.1.6 release, so mainly impacting java2.1 folder.
There was a typo in java2.2 latest release note.

Pinging @daschl for quick review.

This will have to be backported as needed, @amarantha-k and @marijadjovanovic