### PR TITLE
JCBC-902: fix outdated snippets in documents topics

### DIFF
--- a/content/sdks/java-2.2/documents-atomic.dita
+++ b/content/sdks/java-2.2/documents-atomic.dita
@@ -6,29 +6,29 @@
   <body>
     <section>
       <title>Counter</title>
-      
-      
+
+
       <p>The <codeph>counter()</codeph> method allows you to increment or decrement atomically a
         document with numerical content. The method only accepts and returns a
-        <codeph>LongDocument</codeph>. The value stored in the document is incremented
+        <codeph>JsonLongDocument</codeph>. The value stored in the document is incremented
         or decremented depending on the given  <codeph>delta</codeph> . If the delta value
         is a positive number, the value is incremented, and if it is a negative number, the
         value is decremented. You can also pass in an initial value and an expiration
         time.</p>
-      
-      
+
+
       <codeblock outputclass="language-java"><![CDATA[// Increase the counter by 5 and set the initial value to 0 if it does not exist
-Observable<LongDocument> doc = bucket.counter("id", 5, 0);]]></codeblock>
-      
+JsonLongDocument doc = bucket.counter("id", 5, 0);]]></codeblock>
+
       <p>The resulting document contains the new counter value. A very common use case is to implement
         an increasing <codeph>AUTO_INCREMENT</codeph> like counter, where every new user just
-        gets a new ID:</p>
-      
-      <codeblock outputclass="language-java"><![CDATA[bucket
+        gets a new ID (here using the asynchronous API):</p>
+
+      <codeblock outputclass="language-java"><![CDATA[bucket.async()
     .counter("user::id", 1, 1)
-    .map(new Func1<LongDocument, String>() {
+    .map(new Func1<JsonLongDocument, String>() {
         @Override
-        public String call(LongDocument counter) {
+        public String call(JsonLongDocument counter) {
             return "user::" + counter.content();
         }
     })
@@ -38,63 +38,61 @@ Observable<LongDocument> doc = bucket.counter("id", 5, 0);]]></codeblock>
             return bucket.insert(JsonDocument.create(id, JsonObject.empty()));
         }
     }).subscribe();]]></codeblock>
-      
-      
+
+
       <p>This code increases the counter by one, then maps the returned number onto a custom
-        
+
         document ID (here the code prefixes <codeph>user::</codeph>). Afterward, the
         <codeph>insert</codeph> method is executed with the generated ID and an empty
         document content. Because a <codeph>counter</codeph> operation is atomic, the code
         is guaranteed to deliver different user IDs, even when called at the same time from
         multiple threads.</p>
-      
+
       <p>The counter always needs to be
         greater than or equal to zero because negative values are not allowed. If you want to
         decrement a counter, make sure to set it to a value greater than zero initially.</p>
-      
-      
-      
-      <p>If the initial value is omitted and the counter doesn't exists, this is signaled to the user 
-        by propagating a <codeph>DocumentDoesNotExistException</codeph> (since 2.2.0). You 
-        can avoid that by providing an explicit initial value, which could the same as 
-        the delta or even an arbitrary initial value (the delta won't be added to it at 
+
+
+
+      <p>If the initial value is omitted and the counter doesn't exists, this is signaled to the user
+        by propagating a <codeph>DocumentDoesNotExistException</codeph> (since 2.2.0). You
+        can avoid that by providing an explicit initial value, which could the same as
+        the delta or even an arbitrary initial value (the delta won't be added to it at
         counter creation):</p>
-      
-      <codeblock outputclass="language-java"><![CDATA[// Increase the counter by 5 or 
-			create the counter with a value of 4 if it does not exist
-			
-Observable<LongDocument> doc = bucket.counter("id", 5, 4);]]></codeblock>
-      
+
+      <codeblock outputclass="language-java"><![CDATA[// Increase the counter by 5 or create the counter with a value of 4 if it does not exist
+JsonLongDocument doc = bucket.counter("id", 5, 4);]]></codeblock>
+
       <p>If you want to set an expiration time, you need to provide both the initial value and the
         expiration time. This is a constraint imposed by the API because just exposing the
         expiration time would be ambiguous with the initial value (<codeph>long</codeph> and
-        
+
         <codeph>int</codeph>).</p>
-      
-      
+
+
       <codeblock outputclass="language-java"><![CDATA[// Increment by 5, initial 5 and 3 second expiration
-Observable<LongDocument> doc = bucket.counter("id", 5, 5, 3);]]></codeblock>
-      
+JsonLongDocument doc = bucket.counter("id", 5, 5, 3);]]></codeblock>
+
     </section>
-    
+
     <section>
       <title>Append &amp; Prepend</title>
-      
+
       <p>Appending and prepending values to existing documents is also possible. Both the
-        
+
         <codeph>append</codeph> and <codeph>prepend</codeph> operation are atomic, so they
         can be used without further synchronization.</p>
-      
-      
+
+
       <p>
         <note>Both operations only work on binary documents, ideally strings or byte arrays. It does not
           work on JSON documents because it doesn't do any further inspection. Applying
           one of those operations on a JSON document will render it invalid.</note>
       </p>
-      
+
       <p>A <codeph>Document</codeph> needs to be created before values can be appended or prepended.
         Here is an example that creates a document and then appends a string to it:</p>
-      
+
       <codeblock outputclass="language-java"><![CDATA[bucket
     .insert(LegacyDocument.create("doc", "Hello, "))
     .flatMap(doc ->
@@ -103,24 +101,24 @@ Observable<LongDocument> doc = bucket.counter("id", 5, 5, 3);]]></codeblock>
     .flatMap(bucket::get)
     .toBlocking()
     .forEach(doc -> System.err.println(doc.content()));]]></codeblock>
-      
+
       <p>When executed, this code prints <codeph>Hello, World!</codeph>.</p>
     </section>
-    
+
     <section>
       <title>Durability Requirements</title>
-      
-      
+
+
       <p>If no durability requirements are set on the <codeph>append</codeph>, <codeph>prepend</codeph>
         or <codeph>counter</codeph> methods, the operation will succeed when the server
         acknowledges the document in its managed cache layer. While this is a performant
         operation, there might be situations where you want to make sure that your document
         has been persisted or replicated so that it survives power outages and other node
         failures.</p>
-      
-      
+
+
       <p>All atomic operations provide overloads to supply such durability requirements:</p>
-      
+
       <codeblock outputclass="language-java"><![CDATA[D append(D document, PersistTo persistTo);
 D append(D document, ReplicateTo replicateTo);
 D append(D document, PersistTo persistTo, ReplicateTo replicateTo);
@@ -140,15 +138,15 @@ JsonLongDocument counter(String id, long delta, long initial, PersistTo persistT
 JsonLongDocument counter(String id, long delta, long initial, int expiry, PersistTo persistTo);
 JsonLongDocument counter(String id, long delta, long initial, int expiry, ReplicateTo replicateTo);
 JsonLongDocument counter(String id, long delta, long initial, int expiry, PersistTo persistTo, ReplicateTo replicateTo);]]></codeblock>
-      
+
       <p>You can configure either just one or both of the requirements. From an application point of view nothing needs to be
         changed when working with the response, although there is something that need to be kept in mind:</p>
-      
+
       <p>The internal implementation first performs a regular operation and afterward starts polling
         the specifically affected cluster nodes for the state of the document. If something
         fails during this operation (and failing the <codeph>observable</codeph>), the
         original operation might have succeeded nonetheless.</p>
-      
+
     </section>
   </body>
 </topic>

--- a/content/sdks/java-2.2/documents-creating.dita
+++ b/content/sdks/java-2.2/documents-creating.dita
@@ -10,15 +10,21 @@
 		<section>
 			<title>Insert</title>
 
-			<p>The <codeph>insert</codeph> method allows you to store a <codeph>Document</codeph>, if it does not already exist in the bucket. If it does exist, the <codeph>observable</codeph> fails with a <codeph>DocumentAlreadyExistsException</codeph> (or it is thrown in the synchronous counterpart).</p>
+			<p>The <codeph>insert</codeph> method allows you to store a <codeph>Document</codeph>, if it does not already exist in the bucket. If it does exist, the synchronous API throws a <codeph>DocumentAlreadyExistsException</codeph> (or the <codeph>Observable</codeph> propagates it to <codeph>onErro</codeph> in the case of the asynchronous API).</p>
 
 <codeblock outputclass="language-java"><![CDATA[JsonObject content = JsonObject.empty().put("name", "Michael");
 JsonDocument doc = JsonDocument.create("docId", content);
-JsonDocument inserted = bucket.insert(doc)]]></codeblock>
+//this will throw DocumentAlreadyExistException:
+JsonDocument inserted = bucket.insert(doc);]]></codeblock>
 
 <codeblock outputclass="language-java"><![CDATA[JsonObject content = JsonObject.empty().put("name", "Michael");
 JsonDocument doc = JsonDocument.create("docId", content);
-Observable<JsonDocument> inserted = asyncBucket.insert(doc)]]></codeblock>
+Observable<JsonDocument> inserted = bucket.async().insert(doc);
+inserted.subscribe(
+	System.out::println,
+	//this will be called with DocumentAlreadyExistException:
+	Throwable::printStackTrace
+);]]></codeblock>
 
 			<p>If the <codeph>Document</codeph> also has the <codeph>expiry</codeph> time set, it is
 				respected and picked up by the server.</p>
@@ -37,15 +43,20 @@ Observable<JsonDocument> inserted = asyncBucket.insert(doc)]]></codeblock>
 		<section>
 			<title>Upsert</title>
 
-			<p>The <codeph>upsert</codeph> method works similar to <codeph>insert</codeph>, but it also overrides a already stored <codeph>Document</codeph> (so there is no <codeph>DocumentAlreadyExistsException</codeph> thrown.</p>
+			<p>The <codeph>upsert</codeph> method works similar to <codeph>insert</codeph>, but it also overrides a already stored <codeph>Document</codeph> (so there is no <codeph>DocumentAlreadyExistsException</codeph> thrown by the synchronous API nor propagated by the asynchronous API).</p>
 
 <codeblock outputclass="language-java"><![CDATA[JsonObject content = JsonObject.empty().put("name", "Michael");
 JsonDocument doc = JsonDocument.create("docId", content);
-JsonDocument inserted = bucket.upsert(doc)]]></codeblock>
+JsonDocument inserted = bucket.upsert(doc);]]></codeblock>
 
 <codeblock outputclass="language-java"><![CDATA[JsonObject content = JsonObject.empty().put("name", "Michael");
 JsonDocument doc = JsonDocument.create("docId", content);
-Observable<JsonDocument> inserted = asyncBucket.upsert(doc)]]></codeblock>
+Observable<JsonDocument> inserted = bucket.async().upsert(doc);
+inserted.subscribe(
+	System.out::println,
+	//this won't be called:
+	Throwable::printStackTrace
+);]]></codeblock>
 
 			<p>If the <codeph>Document</codeph> also has the <codeph>expiry</codeph> time set, it is
 				respected and picked up by the server.</p>
@@ -64,15 +75,15 @@ Observable<JsonDocument> inserted = asyncBucket.upsert(doc)]]></codeblock>
 
 			<p>Both methods provide overloads to supply such requirements:</p>
 
-<codeblock outputclass="language-java"><![CDATA[Observable<D> insert(D document, PersistTo persistTo);
-Observable<D> insert(D document, ReplicateTo replicateTo);
-Observable<D> insert(D document, PersistTo persistTo, ReplicateTo replicateTo);
+<codeblock outputclass="language-java"><![CDATA[D insert(D document, PersistTo persistTo);
+D insert(D document, ReplicateTo replicateTo);
+D insert(D document, PersistTo persistTo, ReplicateTo replicateTo);
 
-Observable<D> upsert(D document, PersistTo persistTo);
-Observable<D> upsert(D document, ReplicateTo replicateTo);
-Observable<D> upsert(D document, PersistTo persistTo, ReplicateTo replicateTo);]]></codeblock>
+D upsert(D document, PersistTo persistTo);
+D upsert(D document, ReplicateTo replicateTo);
+D upsert(D document, PersistTo persistTo, ReplicateTo replicateTo);]]></codeblock>
 
-			<p>In addition, the synchronous wrapper provides the same methods with custom timeouts.</p>
+			<note type="tip">The synchronous API also provides the same methods with custom timeouts, whereas the asynchronous API in <codeph>AsyncBucket</codeph> would rely on RxJava's <codeph>timeout</codeph> operator.</note>
 
 			<p>You can configure either just one or both of the requirements when inserting or upserting. From an application point of view nothing needs to be changed when working with the response, although there is something that need to be kept in mind:</p>
 
@@ -96,7 +107,7 @@ bucket.insert(document, PersistTo.ONE, ReplicateTo.TWO);]]></codeblock>
 		<section>
 			<title>Batching</title>
 
-			<p>Because everything is asynchronous by default, batching <codeph>inserts</codeph> or <codeph>upserts</codeph> can be achieved with <codeph>Observable</codeph> functionality.</p>
+			<p>Because everything is asynchronous internally, batching <codeph>inserts</codeph> or <codeph>upserts</codeph> can be achieved with <codeph>Observable</codeph> functionality of the <codeph>AsyncBucket</codeph>.</p>
 
 			<p>A combination of <codeph>just()</codeph> and <codeph>flatMap()</codeph> is used to store them without blocking:</p>
 

--- a/content/sdks/java-2.2/documents-deleting.dita
+++ b/content/sdks/java-2.2/documents-deleting.dita
@@ -12,7 +12,7 @@
 			<p>You can remove a document by utilizing the <codeph>remove()</codeph> method.</p>
 
 <codeblock outputclass="language-java"><![CDATA[// Remove the document by its ID.
-Observable<JsonDocument> doc = bucket.remove("id");]]></codeblock>
+JsonDocument doc = bucket.remove("id");]]></codeblock>
 
 			<p>If you pass in a document which also has the CAS value populated, the SDK will make sure to only delete the document if they match:</p>
 
@@ -22,10 +22,10 @@ JsonDocument stored = bucket.upsert(JsonDocument.create("mydoc", JsonObject.crea
 // Delete it with the CAS check included
 JsonDocument removed = bucket.remove(stored);]]></codeblock>
 
-			<p>If successful, the returned <codeph>Document</codeph> has the <codeph>id</codeph> and <codeph>cas</codeph> fields populated, 
+			<p>If successful, the returned <codeph>Document</codeph> has the <codeph>id</codeph> and <codeph>cas</codeph> fields populated,
 				all other fields are set to their default values.</p>
 
-			<p>If the document is not found, a <codeph>DocumentNotFoundException</codeph> is raised. 
+			<p>If the document is not found, a <codeph>DocumentNotFoundException</codeph> is raised.
 				When the document is found but the <codeph>cas</codeph> values do not match, a <codeph>CASMismatchException</codeph> is raised.</p>
 
 		</section>
@@ -33,38 +33,38 @@ JsonDocument removed = bucket.remove(stored);]]></codeblock>
 		<section>
 			<title>Durability Requirements</title>
 
-			<p>If no durability requirements are set on the <codeph>remove</codeph> method, the operation will 
-				succeed when the server acknowledges the document delete in its managed cache layer. 
-				While this is a performant operation, there might be situations where you want to make sure that 
+			<p>If no durability requirements are set on the <codeph>remove</codeph> method, the operation will
+				succeed when the server acknowledges the document delete in its managed cache layer.
+				While this is a performant operation, there might be situations where you want to make sure that
 				your document deletion has been persisted and/or replicated so that it survives power outages and other node failures.</p>
 
 			<p>The remove method provides overloads to supply such requirements:</p>
 
-<codeblock outputclass="language-java"><![CDATA[Observable<D> remove(String id, PersistTo persistTo);
-Observable<D> remove(String id, ReplicateTo replicateTo);
-Observable<D> remove(String id, PersistTo persistTo, ReplicateTo replicateTo);
+<codeblock outputclass="language-java"><![CDATA[JsonDocument remove(String id, PersistTo persistTo);
+JsonDocument remove(String id, ReplicateTo replicateTo);
+JsonDocument remove(String id, PersistTo persistTo, ReplicateTo replicateTo);
 
-Observable<D> remove(D document, PersistTo persistTo);
-Observable<D> remove(D document, ReplicateTo replicateTo);
-Observable<D> remove(D document, PersistTo persistTo, ReplicateTo replicateTo);]]></codeblock>
+D remove(D document, PersistTo persistTo);
+D remove(D document, ReplicateTo replicateTo);
+D remove(D document, PersistTo persistTo, ReplicateTo replicateTo);]]></codeblock>
 
-			<p>You can configure either just one or both of the requirements when removing. 
-				From an application point of view nothing needs to be changed when working with the response, 
+			<p>You can configure either just one or both of the requirements when removing.
+				From an application point of view nothing needs to be changed when working with the response,
 				although there is something that need to be kept in mind:</p>
 
-			<p>The internal implementation first performs a regular <codeph>remove</codeph> operation and afterwards 
-				starts polling the specific affected cluster nodes for the state of the document. 
-				If something fails during this operation (and failing the <codeph>Observable</codeph>), 
+			<p>The internal implementation first performs a regular <codeph>remove</codeph> operation and afterwards
+				starts polling the specific affected cluster nodes for the state of the document.
+				If something fails during this operation (and failing the <codeph>Observable</codeph>),
 				the original operation might have succeeded nonetheless.</p>
 
 <codeblock outputclass="language-java"><![CDATA[// Remove the document and make sure the delete is persisted.
-Observable<JsonDocument> doc = bucket.remove("id", PersistTo.MASTER);
+JsonDocument doc = bucket.remove("id", PersistTo.MASTER);
 
 // Remove the document and make sure the delete is replicated.
-Observable<JsonDocument> doc = bucket.remove("id", ReplicateTo.ONE);
+JsonDocument doc = bucket.remove("id", ReplicateTo.ONE);
 
 // Remove the document and make sure the delete is persisted and replicated.
-Observable<JsonDocument> doc = bucket.remove("id", PersistTo.MASTER, ReplicateTo.ONE);]]></codeblock>
+JsonDocument doc = bucket.remove("id", PersistTo.MASTER, ReplicateTo.ONE);]]></codeblock>
 
 		</section>
 

--- a/content/sdks/java-2.2/documents-retrieving.dita
+++ b/content/sdks/java-2.2/documents-retrieving.dita
@@ -14,8 +14,8 @@
 				by either passing in the <codeph>id</codeph> of the <codeph>Document</codeph> or a
 					<codeph>Document</codeph> itself (where the <codeph>id</codeph> is taken from).</p>
 
-			<codeblock outputclass="language-java"><![CDATA[Observable<JsonDocument> loadedFromId = bucket.get("id");
-Observable<JsonDocument> loadedFromDoc = bucket.get(JsonDocument.create("id"));]]></codeblock>
+			<codeblock outputclass="language-java"><![CDATA[JsonDocument loadedFromId = bucket.get("id");
+JsonDocument loadedFromDoc = bucket.get(JsonDocument.create("id"));]]></codeblock>
 
 			<p>Both methods have the same effect. The latter method is helpful if you are already
 				dealing with <codeph>Document</codeph> instances in your code and you don't want to
@@ -26,26 +26,31 @@ Observable<JsonDocument> loadedFromDoc = bucket.get(JsonDocument.create("id"));]
 				selected as a sensible default. If you want to override this, you can pass in a specific
 					<codeph>Document</codeph> type like this:</p>
 
-			<codeblock outputclass="language-java"><![CDATA[Observable<LegacyDocument> loaded = bucket.get("legacyId", LegacyDocument.class);]]></codeblock>
+			<codeblock outputclass="language-java"><![CDATA[LegacyDocument loaded = bucket.get("legacyId", LegacyDocument.class);]]></codeblock>
 
-			<p>If the document is not found, an empty <codeph>observable</codeph> is returned. This
+			<p>If the document is not found, the blocking API returns null.:</p>
+
+		<codeblock outputclass="language-java"><![CDATA[JsonDocument found = bucket.get("notexisting");
+if (found == null) {
+// doc not found
+} else {
+// doc found
+}]]></codeblock>
+
+			<p>If you are dealing with asynchronous code, an empty <codeph>observable</codeph> is returned instead. This
 				aligns with how <codeph>Observable</codeph> objects are supposed to work by contract,
 				but also makes it easier to deal with the implementation later. If no document is
 				returned, the subsequent operations are just not executed, which avoids having null
 				checks all over the place (if say, a <codeph>Document</codeph> would be returned but
 				with the content set to <codeph>null</codeph>).</p>
-
-			<p>If you are dealing with blocking code, use <codeph>singleOrDefault()</codeph> to avoid a
-					<codeph>NoSuchElementException</codeph> to be thrown. You can either use a
-					<codeph>Document</codeph> populated with default settings or just
-					<codeph>null</codeph>, which can be checked later:</p>
-
-			<codeblock outputclass="language-java"><![CDATA[JsonDocument found = bucket.get("notexisting").toBlocking().singleOrDefault(null);
-if (found == null) {
-    // doc not found
-} else {
-    // doc found
-}]]></codeblock>
+<codeblock outputclass="language-java"><![CDATA[Observable<JsonDocument> updateIfFound = bucket.async().get(potentialNonExistingKey)
+	.map(doc -> doc.content())
+	.filter(jsonObject -> jsonObject.containsKey("test"))
+	.subscribe(
+		//onNext only invoked if the key could be retrieved
+		data -> System.out.println("Data exists and has test key"),
+		error::printStackTrace,
+		() -> System.out.println("Completed"));]]></codeblock>
 
 		</section>
 
@@ -111,7 +116,7 @@ bucket.getFromReplica("id", ReplicaMode.THIRD);]]></codeblock>
 				for the given amount of time.</p>
 
 			<codeblock outputclass="language-java"><![CDATA[// Get and lock for 10 seconds
-Observable<JsonDocument> doc = bucket.getAndLock("id", 10);]]></codeblock>
+JsonDocument doc = bucket.getAndLock("id", 10);]]></codeblock>
 
 			<p>
 				<note>You can only write lock a document for a maximum of 30 seconds. If an invalid lock
@@ -155,14 +160,14 @@ try {
 				expiration time of the document to the specified value.</p>
 
 			<codeblock outputclass="language-java"><![CDATA[// Get and set the new expiration time to 4 seconds
-Observable<JsonDocument> doc = bucket.getAndTouch("id", 4);]]></codeblock>
+JsonDocument doc = bucket.getAndTouch("id", 4);]]></codeblock>
 
 			<p>You can also use the <codeph>touch()</codeph> command if you do not want to read the
 				document and just refresh its expiration time.</p>
 
-			<p>If you specify an expiration time greater than 30 days in seconds (60 seconds * 60
+			<note type="important">If you specify an expiration time greater than 30 days in seconds (60 seconds * 60
 				minutes * 24 hours * 30 days = 2,592,000 seconds) it is considered an absolute time
-				stamp instead of a relative one.</p>
+				stamp instead of a relative one.</note>
 
 		</section>
 	</conbody>

--- a/content/sdks/java-2.2/documents-updating.dita
+++ b/content/sdks/java-2.2/documents-updating.dita
@@ -16,7 +16,7 @@
 
 <codeblock outputclass="language-java"><![CDATA[JsonObject content = JsonObject.empty().put("name", "Michael");
 JsonDocument doc = JsonDocument.create("docId", content);
-Observable<JsonDocument> inserted = bucket.replace(doc)]]></codeblock>
+JsonDocument inserted = bucket.replace(doc)]]></codeblock>
 
 			<p>If the <codeph>Document</codeph> also has the <codeph>expiry</codeph> time set, it will be respected and picked up by the server.</p>
 
@@ -24,9 +24,9 @@ Observable<JsonDocument> inserted = bucket.replace(doc)]]></codeblock>
 
 			<p>The <codeph>Document</codeph> returned as a result is a different one compare to the <codeph>Document</codeph> passed in. It references some values like its <codeph>id</codeph> and <codeph>content</codeph>, but also has the new <codeph>CAS</codeph> value set.</p>
 
-			<p>The following sample will automatically take the <codeph>CAS</codeph> value into account because it is populated from the <codeph>get()</codeph> call and respected on the <codeph>replace()</codeph> call.</p>
+			<p>The following asynchronous sample will automatically take the <codeph>CAS</codeph> value into account because it is populated from the <codeph>get()</codeph> call and respected on the <codeph>replace()</codeph> call.</p>
 
-<codeblock outputclass="language-java"><![CDATA[bucket
+<codeblock outputclass="language-java"><![CDATA[bucket.async()
     .get("id")
     .map(new Func1<JsonDocument, JsonDocument>() {
         @Override
@@ -38,19 +38,19 @@ Observable<JsonDocument> inserted = bucket.replace(doc)]]></codeblock>
     .flatMap(new Func1<JsonDocument, Observable<JsonDocument>>() {
         @Override
         public Observable<JsonDocument> call(JsonDocument document) {
-            return bucket.replace(document);
+            return bucket.async().replace(document);
         }
     }).subscribe();]]></codeblock>
 
     		<p>Since this operation can fail if there is a <codeph>CASMismatchException</codeph>, a common pattern is to retry the complete process until it succeeds:</p>
 
 <codeblock outputclass="language-java"><![CDATA[Observable
-    .defer(() -> bucket.get("id"))
+    .defer(() -> bucket.async()get("id"))
     .map(document -> {
         document.content().put("modified", new Date().getTime());
         return document;
     })
-    .flatMap(bucket::replace)
+    .flatMap(doc -> bucket.async().replace(doc))
     .retryWhen(attempts ->
         attempts.flatMap(n -> {
             if (!(n.getThrowable() instanceof CASMismatchException)) {
@@ -60,11 +60,14 @@ Observable<JsonDocument> inserted = bucket.replace(doc)]]></codeblock>
         })
     )
     .subscribe();]]></codeblock>
-
-    	<p>This code snippet uses <codeph>defer()</codeph> to always do a fresh <codeph>get()</codeph>
-				(remember that a Subject, which is used in the SDK internally, caches the value and
-				therefore a resubscribe will just return the same value. <codeph>defer()</codeph> makes
-				sure to create a new one on every resubscribe). Afterward, it artificially modifies the
+		<p>This code snippet uses <codeph>defer()</codeph>. This was necessary before SDK 2.2.0 to always do a fresh <codeph>get()</codeph>, but is now already done by the SDK.</p>
+		<note type="remember">
+				Prior to 2.2.0, a Subject was directly used in the SDK internally, caching the value and
+				therefore a resubscribe would just return the same value. <codeph>defer()</codeph> makes
+				sure to create a new one on every resubscribe.
+		</note>
+		<p>
+			Afterward, it artificially modifies the
 				document and then tries to store it through a <codeph>replace()</codeph> call. If it
 				succeeds all is good, if it fails with an <codeph>Exception</codeph> the
 					<codeph>retryWhen()</codeph> block is executed. In this block, the code checks if it
@@ -75,12 +78,12 @@ Observable<JsonDocument> inserted = bucket.replace(doc)]]></codeblock>
         <p>Note that since 2.1.2, such code is easier to write by use of the <codeph>RetryBuilder</codeph>:</p>
 
 <codeblock outputclass="language-java"><![CDATA[Observable
-    .defer(() -> bucket.get("id"))
+    .defer(() -> bucket.async().get("id"))
     .map(document -> {
         document.content().put("modified", new Date().getTime());
         return document;
     })
-    .flatMap(bucket::replace)
+    .flatMap(doc -> bucket.async().replace(doc))
     .retryWhen(RetryBuilder
       .anyOf(CASMismatchException.class)
       .delay(Delay.fixed(1, TimeUnit.SECONDS))
@@ -93,13 +96,13 @@ Observable<JsonDocument> inserted = bucket.replace(doc)]]></codeblock>
 		<section>
 			<title>Upsert</title>
 
-			<p>The <codeph>upsert</codeph> method works similar to <codeph>replace</codeph>, but it also stores the <codeph>Document</codeph> if it does not exist (so there is no <codeph>DocumentDoesNotExistException</codeph> thrown.</p>
+			<p>The <codeph>upsert</codeph> method works similar to <codeph>replace</codeph>, but it also stores the <codeph>Document</codeph> if it does not exist (so there is no <codeph>DocumentDoesNotExistException</codeph> thrown).</p>
 
 			<p>It also does not use the <codeph>CAS</codeph> value to handle concurrent updates, even when set on the document. Use <codeph>replace</codeph> instead.</p>
 
 <codeblock outputclass="language-java"><![CDATA[JsonObject content = JsonObject.empty().put("name", "Michael");
 JsonDocument doc = JsonDocument.create("docId", content);
-Observable<JsonDocument> inserted = bucket.upsert(doc)]]></codeblock>
+JsonDocument inserted = bucket.upsert(doc)]]></codeblock>
 
 			<p>If the <codeph>Document</codeph> also has the <codeph>expiry</codeph> time set, it will be respected and picked up by the server.</p>
 
@@ -117,13 +120,13 @@ Observable<JsonDocument> inserted = bucket.upsert(doc)]]></codeblock>
 
 			<p>Both methods provide overloads to supply such requirements:</p>
 
-<codeblock outputclass="language-java"><![CDATA[Observable<D> replace(D document, PersistTo persistTo);
-Observable<D> replace(D document, ReplicateTo replicateTo);
-Observable<D> replace(D document, PersistTo persistTo, ReplicateTo replicateTo);
+<codeblock outputclass="language-java"><![CDATA[D replace(D document, PersistTo persistTo);
+D replace(D document, ReplicateTo replicateTo);
+D replace(D document, PersistTo persistTo, ReplicateTo replicateTo);
 
-Observable<D> upsert(D document, PersistTo persistTo);
-Observable<D> upsert(D document, ReplicateTo replicateTo);
-Observable<D> upsert(D document, PersistTo persistTo, ReplicateTo replicateTo);]]></codeblock>
+D upsert(D document, PersistTo persistTo);
+D upsert(D document, ReplicateTo replicateTo);
+D upsert(D document, PersistTo persistTo, ReplicateTo replicateTo);]]></codeblock>
 
 			<p>You can configure either just one or both of the requirements when inserting or upserting. From an application point of view nothing needs to be changed when working with the response, although there is something that need to be kept in mind:</p>
 
@@ -133,13 +136,13 @@ Observable<D> upsert(D document, PersistTo persistTo, ReplicateTo replicateTo);]
 				(and failing the <codeph>Observable</codeph>), the original operation might have
 				succeeded nonetheless.</p>
 
-<codeblock outputclass="language-java"><![CDATA[// Insert the document and make sure it is persisted to the master node
+<codeblock outputclass="language-java"><![CDATA[// Update the document and make sure it is persisted to the master node
 bucket.replace(document, PersistTo.MASTER);
 
-// Insert the document and make sure it is replicate to one replica node
+// Update the document and make sure it is replicate to one replica node
 bucket.replace(document, ReplicateTo.ONE);
 
-// Insert the document and make sure it is persisted to one node and replicated to two
+// Update the document and make sure it is persisted to one node and replicated to two
 bucket.replace(document, PersistTo.ONE, ReplicateTo.TWO);]]></codeblock>
 
 		</section>
@@ -147,7 +150,7 @@ bucket.replace(document, PersistTo.ONE, ReplicateTo.TWO);]]></codeblock>
 		<section>
 			<title>Batching</title>
 
-			<p>Because everything is asynchronous by default, batching <codeph>replaces</codeph> or <codeph>upserts</codeph> can be achieved with <codeph>Observable</codeph> functionality.</p>
+			<p>Because everything is asynchronous internally, batching <codeph>replaces</codeph> or <codeph>upserts</codeph> can be achieved with <codeph>Observable</codeph> functionality of the <codeph>AsyncBucket</codeph>.</p>
 
 			<p>A combination of <codeph>just()</codeph> and <codeph>flatMap()</codeph> is used to store them without blocking:</p>
 


### PR DESCRIPTION
Mainly async code used in place of sync code (or missing bucket.async()).

This also covers DOC-1007 and JCBC-845.

@daschl can you review before this can be merged in?