### PR TITLE
Changes for Java 2.2.4

### DIFF
--- a/content/cli/cbcli/setting-alert.dita
+++ b/content/cli/cbcli/setting-alert.dita
@@ -80,6 +80,10 @@
               <entry>Node not auto failed-over as cluster was too small.</entry>
             </row>
             <row>
+              <entry><codeph>--alert-auto-failover-disabled</codeph></entry>
+              <entry>Alerts if a node is down but autofailover is disabled.</entry>
+            </row>
+            <row>
               <entry><codeph>--alert-ip-changed</codeph></entry>
               <entry>Node ip address changed unexpectedly.</entry>
             </row>

--- a/content/sdks/java-2.2/download-links.dita
+++ b/content/sdks/java-2.2/download-links.dita
@@ -9,7 +9,7 @@
 	<conbody>
 
 		<section>
-			<title>Current Release (2.2.3)</title>
+			<title>Current Release (2.2.4)</title>
 			<p>To use the Java SDK, point your application project object model (POM) to the library, which
 				is available on Maven Central. Here is a typical <filepath>pom.xml</filepath> that you
 				can copy and paste into your Java project:</p>
@@ -17,15 +17,20 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>java-client</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
 </dependencies>
 ]]></codeblock>
 
 			<ul>
-				<li>2.2.3
+				<li>2.2.4
 					<msgph outputclass="stable">GA</msgph>
 					<msgph outputclass="current">CURRENT</msgph>
+					- <xref href="http://packages.couchbase.com/clients/java/2.2.4/Couchbase-Java-Client-2.2.4.zip" format="html" scope="external">Download</xref>
+					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-java-client-2.2.4/" format="html" scope="external">API Reference</xref>
+					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-core-io-1.2.4/" format="html" scope="external">Core API Reference</xref></li>
+				<li>2.2.3
+					<msgph outputclass="stable">GA</msgph>
 					- <xref href="http://packages.couchbase.com/clients/java/2.2.3/Couchbase-Java-Client-2.2.3.zip" format="html" scope="external">Download</xref>
 					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-java-client-2.2.3/" format="html" scope="external">API Reference</xref>
 					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-core-io-1.2.3/" format="html" scope="external">Core API Reference</xref></li>

--- a/content/sdks/java-2.2/getting-started.dita
+++ b/content/sdks/java-2.2/getting-started.dita
@@ -21,7 +21,7 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>java-client</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
 </dependencies>
 ]]></codeblock>

--- a/content/sdks/java-2.2/migrate.dita
+++ b/content/sdks/java-2.2/migrate.dita
@@ -51,10 +51,13 @@
 				they are as shared as much as possible, and the <codeph>Cluster</codeph> and
 					<codeph>Bucket</codeph> references can always be reused.</p>
 
-			<p>To differentiate this rewrite from the previous generation, the <codeph>Maven</codeph>
-				artifact has been renamed from <codeph>couchbase-client</codeph> to
-					<codeph>java-client</codeph>. It has minimal transitive dependencies (by embedding a
-				few internal dependencies like Netty), most essentially RxJava 1.x:</p>
+			<p>The <codeph>Maven</codeph> artifact has been renamed from <codeph>couchbase-client</codeph> to
+				java-client to differentiate this rewrite from the previous generation. It has
+				minimal transitive dependencies (by embedding a few internal dependencies like
+				Netty), most notably</p>
+			<p/>
+			<p/>
+			<p> RxJava 1.x:</p>
 
 			<codeblock outputclass="language-xml"><![CDATA[<dependencies>
     <dependency>

--- a/content/sdks/java-2.2/migrate.dita
+++ b/content/sdks/java-2.2/migrate.dita
@@ -60,7 +60,7 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>java-client</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
 </dependencies>
 ]]></codeblock>

--- a/content/sdks/java-2.2/release-notes.dita
+++ b/content/sdks/java-2.2/release-notes.dita
@@ -7,8 +7,8 @@
 		<conbody>
 			<section>
 				<title>Couchbase Java Client 2.2.4 GA (3 February 2016)</title>
-				<p>Version 2.2.4 is the fourth bugfix release of the 2.2 series. It brings bugfixes, enhancements and correctness
-				improvements.</p>
+				<p>Version 2.2.4 is the fourth bugfix release of the 2.2 series. It brings bug fixes,
+				enhancements, and correctness improvements.</p>
 			</section>
 
 			<section id="ga224-features">
@@ -16,9 +16,15 @@
 				<p>This release contains the following enhancements:</p>
 
 				<ul>
-					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-849" format="html" scope="external">JCBC-849</xref>: Experimental support for the <codeph>SubDocument</codeph> feature has been added. Subdocument allows to only transmit a specific part of a JSON document you are interested in.</li>
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-849" format="html"
+						scope="external">JCBC-849</xref>: Experimental support for the
+						<codeph>SubDocument</codeph> feature has been added. Subdocument allows you
+					to transmit only the specific part of a JSON document that you want.</li>
 
-					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-850" format="html" scope="external">JCBC-850</xref>: Experimental support for <codeph>Full Text Search</codeph>. FTS is a new type of index in Couchbase Server 4.5 that allows you to do eg. fuzzy text search queries.</li>
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-850" format="html"
+						scope="external">JCBC-850</xref>: Experimental support for <term>Full Text
+						Search (FTS)</term>, a new type of index in Couchbase Server 4.5 that allows
+					you to do, for example,  the fuzzy text search queries.</li>
 
 					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-869" format="html" scope="external">JCBC-869</xref>: N1QL row values can now be deserialized by a custom library since they expose the raw value as a <codeph>byte[]</codeph> through <codeph>byteValue()</codeph>. The <codeph>JsonObject</codeph> <codeph>value()</codeph> is deserialized lazily from this byte array, so never invoking it will completely avoid the overhead of JsonObject deserialization if you don't need it.</li>
 
@@ -40,7 +46,10 @@
 				<ul>
 					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-278" format="html" scope="external">JVMCBC-278</xref>: A socket timeout on a Netty endpoint would prevent any further attempt at reconnecting the client altogether. A message in the logs stating that "Socket connect took longer than specified timeout" would appear and the client wouldn't reconnect to the node when it would come back online.</li>
 
-					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-288" format="html" scope="external">JVMCBC-288</xref>: Various <codeph>Locators</codeph> now correctly only locate <codeph>Node</codeph> that have the proper service enabled.</li>
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-288" format="html"
+						scope="external">JVMCBC-288</xref>: Various <codeph>Locators</codeph> now
+					correctly only locate a <codeph>Node</codeph> that has the proper service
+					enabled.</li>
 
 					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-903" format="html" scope="external">JCBC-903</xref>: Some <codeph>CouchbaseFeature</codeph> enums were referencing wrong Couchbase Server version.</li>
 
@@ -48,7 +57,10 @@
 
 					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-277" format="html" scope="external">JVMCBC-277</xref>: Netty sources are now properly relocated in the source jar to match the shaded classes in the main jar (looking at sources and entering the Netty shaded classes should now work).</li>
 
-					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-286" format="html" scope="external">JVMCBC-286</xref>: Build process now checks both in core and client that only classes and methods that are actually available in a Java 6 JRE/JDK are used.</li>
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-286" format="html"
+						scope="external">JVMCBC-286</xref>: Build process now checks both in core
+					and client that only classes and methods that are available in a Java 6 JRE/JDK
+					are used.</li>
 				</ul>
 			</section>
 
@@ -59,7 +71,7 @@
 				<title>Couchbase Java Client 2.2.3 GA (5 January 2016)</title>
 
 				<p>Version 2.2.3 is the third bug fix release of the 2.2 series. It brings bug fixes,
-					enhancements and correctness improvements.</p>
+				enhancements, and correctness improvements.</p>
 
 			</section>
 
@@ -208,7 +220,10 @@
 
 				<ul>
 					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-250" format="html"
-							scope="external">JVMCBC-250</xref>: An explicit, lower (configurable) socket connect timeout is now always used when connections are established. This provides more reliable semantics during the socket open phase and allows for faster retrying mechanisms inside the core layer.</li>
+						scope="external">JVMCBC-250</xref>: An explicit, lower (configurable) socket
+					connect timeout is now always used when connections are established. This
+					provides more reliable semantics during the socket open phase and allows for
+					faster-retrying mechanisms inside the core layer.</li>
 					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-242" format="html"
 						scope="external">JVMCBC-242</xref>, <xref
 						href="https://www.couchbase.com/issues/browse/JVMCBC-247" format="html"
@@ -216,18 +231,25 @@
 					and Netty have been bumped to their latest bugfix releases for increased
 					stability.</li>
 					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-241" format="html"
-							scope="external">JVMCBC-241</xref>, <xref href="https://www.couchbase.com/issues/browse/JVMCBC-253" format="html"
-							scope="external">JVMCBC-253</xref>: Experimental Support for DCP has been improved. ERANGE and ROLLBACK during the stream open phase are now handled properly. Also, it is now possible to partially initialize streams (for example to only get the streams for a specific number of partitions).</li>
+						scope="external">JVMCBC-241</xref>, <xref
+						href="https://www.couchbase.com/issues/browse/JVMCBC-253" format="html"
+						scope="external">JVMCBC-253</xref>: Experimental Support for DCP has been
+					improved. <codeph>ERANGE</codeph> and <codeph>ROLLBACK</codeph> during the
+					stream open phase are now handled properly. Also, it is now possible to
+					partially initialize streams (for example to only get the streams for a specific
+					number of partitions).</li>
 					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-246" format="html"
-						scope="external">JVMCBC-246</xref>: The KeyValue "STAT" command is now
-					implemented in the core layer, allowing for more flexibility in the future to
-					grab key or cluster statistics. Note that STATS are not exposed to the
-						<codeph>java-client </codeph>at this point, but might be in the future as
+						scope="external">JVMCBC-246</xref>: The KeyValue <cmdname>STAT</cmdname>
+					command is now implemented in the core layer, allowing for more flexibility in
+					the future to grab key or cluster statistics. Note that STATS are not exposed to
+					the <codeph>java-client </codeph>at this point, but might be in the future as
 					encapsulated APIs.</li>
 					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-245" format="html"
 							scope="external">JVMCBC-245</xref>: When latency metric events are emitted, the original time unit is now included, so later analysis does not need to reference back to the source code for the time unit used.</li>
 					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-854" format="html"
-							scope="external">JCBC-854</xref>: Encoding for all String-based document types has been made faster by a factor of 2 and more, this also includes the RawJsonDocument.</li>
+						scope="external">JCBC-854</xref>: Encoding for all string-based document
+					types has been made faster by a factor of 2 and more, this also includes the
+						<codeph>RawJsonDocument</codeph>.</li>
 				</ul>
 			</section>
 

--- a/content/sdks/java-2.2/release-notes.dita
+++ b/content/sdks/java-2.2/release-notes.dita
@@ -5,11 +5,60 @@
 	<shortdesc>Release notes for the 2.2 version of the Java SDK.</shortdesc>
 
 		<conbody>
+			<section>
+				<title>Couchbase Java Client 2.2.4 GA (3 February 2016)</title>
+				<p>Version 2.2.4 is the fourth bugfix release of the 2.2 series. It brings bugfixes, enhancements and correctness
+				improvements.</p>
+			</section>
+
+			<section id="ga224-features">
+				<title>New features and behavioral changes</title>
+				<p>This release contains the following enhancements:</p>
+
+				<ul>
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-849" format="html" scope="external">JCBC-849</xref>: Experimental support for the <codeph>SubDocument</codeph> feature has been added. Subdocument allows to only transmit a specific part of a JSON document you are interested in.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-850" format="html" scope="external">JCBC-850</xref>: Experimental support for <codeph>Full Text Search</codeph>. FTS is a new type of index in Couchbase Server 4.5 that allows you to do eg. fuzzy text search queries.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-869" format="html" scope="external">JCBC-869</xref>: N1QL row values can now be deserialized by a custom library since they expose the raw value as a <codeph>byte[]</codeph> through <codeph>byteValue()</codeph>. The <codeph>JsonObject</codeph> <codeph>value()</codeph> is deserialized lazily from this byte array, so never invoking it will completely avoid the overhead of JsonObject deserialization if you don't need it.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-279" format="html" scope="external">JVMCBC-279</xref>: The bucket's name has been added to the <codeph>MutationToken</codeph> produced when enhanced durability is activated.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-282" format="html" scope="external">JVMCBC-282</xref>: When a node is being reconnected, a notification is sent through the <codeph>EventBus</codeph>.</li>
+
+  					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-281" format="html" scope="external">JVMCBC-281</xref>,
+					<xref href="https://www.couchbase.com/issues/browse/JVMCBC-284" format="html" scope="external">JVMCBC-284</xref>,
+					<xref href="https://www.couchbase.com/issues/browse/JVMCBC-285" format="html" scope="external">JVMCBC-285</xref>,
+					<xref href="https://www.couchbase.com/issues/browse/JVMCBC-287" format="html" scope="external">JVMCBC-287</xref>:
+					Various allocating and caching changes for performance improvements.</li>
+				</ul>
+			</section>
+
+			<section id="ga224-fixes">
+				<title>Fixed Issues</title>
+				<p>This release fixes the following issues:</p>
+				<ul>
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-278" format="html" scope="external">JVMCBC-278</xref>: A socket timeout on a Netty endpoint would prevent any further attempt at reconnecting the client altogether. A message in the logs stating that "Socket connect took longer than specified timeout" would appear and the client wouldn't reconnect to the node when it would come back online.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-288" format="html" scope="external">JVMCBC-288</xref>: Various <codeph>Locators</codeph> now correctly only locate <codeph>Node</codeph> that have the proper service enabled.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-903" format="html" scope="external">JCBC-903</xref>: Some <codeph>CouchbaseFeature</codeph> enums were referencing wrong Couchbase Server version.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-904" format="html" scope="external">JCBC-904</xref>: The <codeph>socketConnectTimeout</codeph> tuning can now properly be set on the <codeph>CouchbaseEnvironment</codeph>.</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-277" format="html" scope="external">JVMCBC-277</xref>: Netty sources are now properly relocated in the source jar to match the shaded classes in the main jar (looking at sources and entering the Netty shaded classes should now work).</li>
+
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-286" format="html" scope="external">JVMCBC-286</xref>: Build process now checks both in core and client that only classes and methods that are actually available in a Java 6 JRE/JDK are used.</li>
+				</ul>
+			</section>
+
+
+
 
 			<section>
 				<title>Couchbase Java Client 2.2.3 GA (5 January 2016)</title>
 
-				<p>Version 2.2.3 is the third bug fix release of the 2.2 series. It brings bug fixes, 
+				<p>Version 2.2.3 is the third bug fix release of the 2.2 series. It brings bug fixes,
 					enhancements and correctness improvements.</p>
 
 			</section>

--- a/content/sdks/java-2.2/tutorial3.dita
+++ b/content/sdks/java-2.2/tutorial3.dita
@@ -156,7 +156,7 @@ java -jar beersample-java2.jar]]></codeblock>
 		<dependency>
 			<groupId>com.couchbase.client</groupId>
 			<artifactId>java-client</artifactId>
-			<version>2.2.3</version>
+			<version>2.2.4</version>
 
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
All changes for Java 2.2.4, including the file tutorial3.dita, which is not part of this ditamap.
Added option for CLI setting-alert