### PR TITLE
C: Remove lipo reference

### DIFF
--- a/content/sdks/c-2.4/download-install.dita
+++ b/content/sdks/c-2.4/download-install.dita
@@ -12,140 +12,133 @@
 				the <xref href="http://www.stack.nl/%7Edimitri/doxygen/" format="html" scope="external"
 					>Doxygen</xref> utility. See the source <codeph>README</codeph> for instructions on
 				how to generate the documentation locally.</p>
-		
-	<section>
-		<title>Linux quick start</title>
-	
-			<p>You can use the simple setup script to configure your system to get the most common C SDK
-				packages. A C SDK package can be used on any Enterprise Linux (CentOS, Red Hat
-				Enterprise Linux) or Debian-based (Ubuntu, Debian) distribution. The script performs
-				the following installation tasks:<ul id="ol_cfm_kfb_bq">
-					<li>Configures your distribution to use the Couchbase software repositories</li>
-					<li>Installs the core library distribution</li>
-					<li>Installs the command line utilities (<cmdname>cbc</cmdname> and
-							<cmdname>cbc-pillowfight</cmdname>)</li>
-					<li>Installs the development files needed for using SDKs that rely on the C
-						SDK</li>
-				</ul></p>
-			<p>To use the script, you need to have Perl installed on your system. Virtually all Linux
-				distributions already have Perl installed as a core component of the distribution. The
-				script prompts you whenever it needs to make changes to your system or packages.</p>
-			<p>To get started, download the script from <xref
-					href="http://packages.couchbase.com/clients/c/couchbase-csdk-setup" format="html"
-					scope="external">http://packages.couchbase.com/clients/c/couchbase-csdk-setup</xref>.
-				To run the script, enter the following
-				commands:<codeblock outputclass="language-bash">shell> wget http://packages.couchbase.com/clients/c/couchbase-csdk-setup
-shell> sudo perl couchbase-csdk-setup</codeblock></p>
-
-		
-	</section>
+        <section>
+            <title>Installing from repositories (Linux)</title>
+            <p>If you are using a Debian or Redhat based Linux distribution, you may install from
+                one of the Couchbase package repositories. You can set up the Couchbase repositories
+                by using the <codeph>couchbase-release</codeph> package for your distribution. You
+                will typically want to install the development files (which will also install the
+                core library) and the command line utilities.</p>
+            <codeblock spectitle="Debian/Ubuntu"># Only needed during first-time setup:
+wget http://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-0-noarch.deb
+sudo dpkg -i couchbase-release-1.0-0-noarch.deb
+# Will install or upgrade packages
+sudo apt-get update
+sudo apt-get install libcouchbase-dev libcouchbase2-bin build-essential</codeblock>
+            <codeblock spectitle="CentOS/RHEL"># Only needed during first-time setup:
+wget http://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-0.noarch.rpm
+sudo rpm -ivH couchbase-release-1.0-0.noarch.rpm
+# Will install or upgrade existing packages
+sudo yum install libcouchbase-devel libcouchbase2-bin gcc gcc-c++</codeblock>
+            <note>Debian Jessie (8) does not have official supported packages or repositories.
+                Debian Wheezy/Ubuntu Trusty packages may still work on that release.</note>
+        </section>
 			
 			
 			
-	<section>
-			<title>Linux advanced installation </title><p>If you want to install the C SDK manually,
-				either from a static binary package or by manually configuring the repositories, you
-				can use the following procedures. </p><p><b>Common Binary Packages</b></p><p>The
-				various Linux distributions contain the following packages:<ul id="ul_shp_qnc_bq">
-					<li><codeph>libcouchbase2-core</codeph>: The core library package</li>
-					<li><codeph>libcouchbase-dev</codeph> (or <codeph>libcouchbase-devel</codeph>):
-						The development package, required if building SDKs which depend on the C
-						SDK</li>
-					<li><codeph>libcouchbase2-bin</codeph>: The command line utilities
-							(<cmdname>cbc</cmdname> and <cmdname>cbc-pillowfight</cmdname>)</li>
-					<li><codeph>libcouchbase2-libevent</codeph>: Optional but recommended component
-						for I/O performance. Can also be used to integrate with
-							<apiname>libevent</apiname> (see <xref
-							href="external-eventloop.dita#concept_nf3_kz4_p4"/>).</li>
-					<li><codeph>libcouchbase2-libev</codeph>: Optional, for use with applications
-						that make use of event loop integration with <apiname>libev</apiname> (see
-							<xref href="external-eventloop.dita#concept_nf3_kz4_p4"/>). </li>
-				</ul></p><p><b>Configuring yum repositories (CentOS, Redhat Enteprise
-			Linux)</b></p>This section assumes you know how to add an external <xref
-				href="http://yum.baseurl.org" format="html" scope="external">yum</xref> repository
-			and Linux quick start explains the steps it will perform on your distribution. To
-			configure the repository: <ol id="ol_b12_1lb_bq">
-				<li>Find the appropriate repository location for your distribution in the following
-					table. CentOS and RHEL allow 32-bit packages to be installed on a 64-bit system.
-					This is usually not what you want, so ensure that you use the 64-bit repository
-					for your 64-bit system (unless you specifically want the 32-bit SDK). <table>
-						<tgroup cols="3">
-							<thead>
-								<row>
-									<entry>Version</entry>
-									<entry>Architecture</entry>
-									<entry>Repository</entry>
-								</row>
-							</thead>
-							<tbody>
-								<row>
-									<entry>6</entry>
-									<entry>32-bit</entry>
-									<entry><codeph>http://packages.couchbase.com/rpm/6.2/i686</codeph></entry>
-								</row>
-								<row>
-									<entry>6</entry>
-									<entry>64-bit</entry>
-									<entry><codeph>http://packages.couchbase.com/rpm/6.2/x86_64</codeph></entry>
-								</row>
-								<row>
-									<entry>7</entry>
-									<entry>64-bit</entry>
-									<entry><codeph>http://packages.couchbase.com/rpm/7/x86_64</codeph></entry>
-								</row>
-							</tbody>
-						</tgroup>
-					</table></li>
-				<li>Create a <filepath>couchbase.repo</filepath> file in your
-						<filepath>/etc/yum.repos.d</filepath> directory. It should look similar to
-					the
-					following:<codeblock>[couchbase]
+	<section><title>Linux advanced installation </title><p>If you want to install the C SDK manually,
+                either from a static binary package or by manually configuring the repositories, you
+                can use the following procedures.</p><p><b>Common Binary Packages</b></p><p>The
+                various Linux distributions contain the following packages:<ul id="ul_shp_qnc_bq">
+                    <li><codeph>libcouchbase2-core</codeph>: The core library package</li>
+                    <li><codeph>libcouchbase-dev</codeph> (or <codeph>libcouchbase-devel</codeph>):
+                        The development package, required if building SDKs which depend on the C
+                        SDK</li>
+                    <li><codeph>libcouchbase2-bin</codeph>: The command line utilities
+                            (<cmdname>cbc</cmdname> and <cmdname>cbc-pillowfight</cmdname>)</li>
+                    <li><codeph>libcouchbase2-libevent</codeph>: Optional but recommended component
+                        for I/O performance. Can also be used to integrate with
+                            <apiname>libevent</apiname> (see <xref
+                            href="external-eventloop.dita#concept_nf3_kz4_p4"/>).</li>
+                    <li><codeph>libcouchbase2-libev</codeph>: Optional, for use with applications
+                        that make use of event loop integration with <apiname>libev</apiname> (see
+                            <xref href="external-eventloop.dita#concept_nf3_kz4_p4"/>). </li>
+                </ul></p><p><b>Configuring yum repositories (CentOS, Redhat Enteprise
+            Linux)</b></p>This section assumes you know how to add an external <xref
+                href="http://yum.baseurl.org" format="html" scope="external">yum</xref> repository
+            and Linux quick start explains the steps it will perform on your distribution. To
+            configure the repository: <ol id="ol_b12_1lb_bq">
+                <li>Find the appropriate repository location for your distribution in the following
+                    table. CentOS and RHEL allow 32-bit packages to be installed on a 64-bit system.
+                    This is usually not what you want, so ensure that you use the 64-bit repository
+                    for your 64-bit system (unless you specifically want the 32-bit SDK). <table>
+                        <tgroup cols="3">
+                            <thead>
+                                <row>
+                                    <entry>Version</entry>
+                                    <entry>Architecture</entry>
+                                    <entry>Repository</entry>
+                                </row>
+                            </thead>
+                            <tbody>
+                                <row>
+                                    <entry>6</entry>
+                                    <entry>32-bit</entry>
+                                    <entry><codeph>http://packages.couchbase.com/rpm/6.2/i686</codeph></entry>
+                                </row>
+                                <row>
+                                    <entry>6</entry>
+                                    <entry>64-bit</entry>
+                                    <entry><codeph>http://packages.couchbase.com/rpm/6.2/x86_64</codeph></entry>
+                                </row>
+                                <row>
+                                    <entry>7</entry>
+                                    <entry>64-bit</entry>
+                                    <entry><codeph>http://packages.couchbase.com/rpm/7/x86_64</codeph></entry>
+                                </row>
+                            </tbody>
+                        </tgroup>
+                    </table></li>
+                <li>Create a <filepath>couchbase.repo</filepath> file in your
+                        <filepath>/etc/yum.repos.d</filepath> directory. It should look similar to
+                    the
+                    following:<codeblock>[couchbase]
 enabled = 1
 name = Couchbase package repository
 baseurl = REPLACE THIS WITH THE ACTUAL REPOSITORY FOR YOUR PLATFORM
 gpgcheck = 1
 gpgkey = http://packages.couchbase.com/rpm/couchbase-rpm.key </codeblock></li>
-			</ol><p><b>Configuring APT repositories (Debian, Ubuntu)</b>
-			</p><p>This section assumes some knowledge of <xref href="https://wiki.debian.org/Apt"
-					format="html" scope="external">Apt</xref> and Linux quick start explains the
-				steps it will perform on your distribution. To configure the repository:<i/></p><ol
-				id="ol_alc_nmb_bq">
-				<li>Download the Couchbase GPG key from
-						<filepath>http://packages.couchbase.com/ubuntu/couchbase.key</filepath>.</li>
-				<li>Add the key to the list of trusted package keys. Use the <codeph>apt-key
-						add</codeph> command. For example, <codeph>apt-key add
-						couchbase.key</codeph>.</li>
-				<li>Create a <filepath>couchbase.list</filepath> file in
-						<filepath>/etc/apt/sources.list.d</filepath>. The file should contain the
-					repository for your distribution. Repositories are available for the following
-					distributions: <table id="table_trf_ymb_bq">
-						<tgroup cols="2">
-							<thead>
-								<row>
-									<entry>Distribution</entry>
-									<entry>Repository Entry</entry>
-								</row>
-							</thead>
-							<tbody>
-								<row>
-									<entry>Precise (Ubuntu 12.04)</entry>
-									<entry><codeph>deb http://packages.couchbase.com/ubuntu precise
-											precise/main</codeph></entry>
-								</row>
-								<row>
-									<entry>Trusty (Ubuntu 14.04)</entry>
-									<entry><codeph>deb http://packages.couchbase.com/ubuntu trusty
-											trusty/main</codeph></entry>
-								</row>
-								<row>
-									<entry>Debian Wheezy (Stable)</entry>
-									<entry><codeph>deb http://packages.couchbase.com/ubuntu wheezy
-											wheezy/main</codeph></entry>
-								</row>
-							</tbody>
-						</tgroup>
-					</table></li>
-			</ol></section>
+            </ol><p><b>Configuring APT repositories (Debian, Ubuntu)</b>
+            </p><p>This section assumes some knowledge of <xref href="https://wiki.debian.org/Apt"
+                    format="html" scope="external">Apt</xref> and Linux quick start explains the
+                steps it will perform on your distribution. To configure the repository:<i/></p><ol
+                id="ol_alc_nmb_bq">
+                <li>Download the Couchbase GPG key from
+                        <filepath>http://packages.couchbase.com/ubuntu/couchbase.key</filepath>.</li>
+                <li>Add the key to the list of trusted package keys. Use the <codeph>apt-key
+                        add</codeph> command. For example, <codeph>apt-key add
+                        couchbase.key</codeph>.</li>
+                <li>Create a <filepath>couchbase.list</filepath> file in
+                        <filepath>/etc/apt/sources.list.d</filepath>. The file should contain the
+                    repository for your distribution. Repositories are available for the following
+                    distributions: <table id="table_trf_ymb_bq">
+                        <tgroup cols="2">
+                            <thead>
+                                <row>
+                                    <entry>Distribution</entry>
+                                    <entry>Repository Entry</entry>
+                                </row>
+                            </thead>
+                            <tbody>
+                                <row>
+                                    <entry>Precise (Ubuntu 12.04)</entry>
+                                    <entry><codeph>deb http://packages.couchbase.com/ubuntu precise
+                                            precise/main</codeph></entry>
+                                </row>
+                                <row>
+                                    <entry>Trusty (Ubuntu 14.04)</entry>
+                                    <entry><codeph>deb http://packages.couchbase.com/ubuntu trusty
+                                            trusty/main</codeph></entry>
+                                </row>
+                                <row>
+                                    <entry>Debian Wheezy (Stable)</entry>
+                                    <entry><codeph>deb http://packages.couchbase.com/ubuntu wheezy
+                                            wheezy/main</codeph></entry>
+                                </row>
+                            </tbody>
+                        </tgroup>
+                    </table></li>
+            </ol></section>
 		
 			
 			

--- a/content/sdks/c-2.4/download-install.dita
+++ b/content/sdks/c-2.4/download-install.dita
@@ -157,9 +157,6 @@ gpgkey = http://packages.couchbase.com/rpm/couchbase-rpm.key </codeblock></li>
 				>Homebrew</xref>:</p>
 				<codeblock outputclass="language-bash">$ brew update # Needed if upgrading to a newer version
 $ brew install libcouchbase </codeblock>
-			<p>If you are using an extension for a 32-bit interpreter (check by executing <codeph>lipo -info
-					/path/to/interp</codeph>), you should install the C SDK with the following command:
-				<codeblock>$ brew install libcouchbase --universal</codeblock></p>
 			</section>
 			
 	<section>


### PR DESCRIPTION
This is confusing for most homebrew users, and is a standard homebrew
option rather than couchbase-specifici