### PR TITLE
download links for php 2.2.0beta3

### DIFF
--- a/content/sdks/php-2.0/download-links.dita
+++ b/content/sdks/php-2.0/download-links.dita
@@ -20,16 +20,30 @@
 					href="https://github.com/couchbaselabs/php-couchbase" format="html" scope="external"
 					>source</xref> for the SDK and building it directly.</p>
 			<ul>
+				<li>2.2.0beta3<msgph outputclass="beta">BETA</msgph>
+					<ul>
+						<li><xref href="http://docs.couchbase.com/sdk-api/couchbase-php-client-2.2.0beta3/" format="html" scope="external">API Reference</xref></li>
+						<li>PHP 5.6 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.6-nts-vc11-x64.zip" format="html" scope="external">x64</xref>,
+							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.6-nts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
+						<li>PHP 5.6 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.6-zts-vc11-x64.zip" format="html" scope="external">x64</xref>,
+							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.6-zts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
+						<li>PHP 5.5 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.5-nts-vc11-x64.zip" format="html" scope="external">x64</xref>,
+							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.5-nts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
+						<li>PHP 5.5 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.5-zts-vc11-x64.zip" format="html" scope="external">x64</xref>,
+							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.5-zts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
+						<li>PHP 5.4 VC9 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.4-nts-vc9-x86.zip" format="html" scope="external">x86</xref></li>
+						<li>PHP 5.4 VC9 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta3-5.4-zts-vc9-x86.zip" format="html" scope="external">x86</xref></li>
+					</ul></li>
 				<li>2.2.0beta2<msgph outputclass="beta">BETA</msgph>
 					<ul>
 						<li><xref href="http://docs.couchbase.com/sdk-api/couchbase-php-client-2.2.0beta2/" format="html" scope="external">API Reference</xref></li>
-						<li>PHP 5.6 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.6-nts-vc11-x64.zip" format="html" scope="external">x64</xref>, 
+						<li>PHP 5.6 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.6-nts-vc11-x64.zip" format="html" scope="external">x64</xref>,
 							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.6-nts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
-						<li>PHP 5.6 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.6-zts-vc11-x64.zip" format="html" scope="external">x64</xref>, 
+						<li>PHP 5.6 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.6-zts-vc11-x64.zip" format="html" scope="external">x64</xref>,
 							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.6-zts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
-						<li>PHP 5.5 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.5-nts-vc11-x64.zip" format="html" scope="external">x64</xref>, 
+						<li>PHP 5.5 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.5-nts-vc11-x64.zip" format="html" scope="external">x64</xref>,
 							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.5-nts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
-						<li>PHP 5.5 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.5-zts-vc11-x64.zip" format="html" scope="external">x64</xref>, 
+						<li>PHP 5.5 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.5-zts-vc11-x64.zip" format="html" scope="external">x64</xref>,
 							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.5-zts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
 						<li>PHP 5.4 VC9 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.4-nts-vc9-x86.zip" format="html" scope="external">x86</xref></li>
 						<li>PHP 5.4 VC9 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.2.0beta2-5.4-zts-vc9-x86.zip" format="html" scope="external">x86</xref></li>
@@ -38,13 +52,13 @@
 					<msgph outputclass="current">CURRENT</msgph>
 					<ul>
 						<li><xref href="http://docs.couchbase.com/sdk-api/couchbase-php-client-2.1.0/" format="html" scope="external">API Reference</xref></li>
-						<li>PHP 5.6 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.6-nts-vc11-x64.zip" format="html" scope="external">x64</xref>, 
+						<li>PHP 5.6 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.6-nts-vc11-x64.zip" format="html" scope="external">x64</xref>,
 							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.6-nts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
-						<li>PHP 5.6 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.6-zts-vc11-x64.zip" format="html" scope="external">x64</xref>, 
+						<li>PHP 5.6 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.6-zts-vc11-x64.zip" format="html" scope="external">x64</xref>,
 							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.6-zts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
-						<li>PHP 5.5 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.5-nts-vc11-x64.zip" format="html" scope="external">x64</xref>, 
+						<li>PHP 5.5 VC11 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.5-nts-vc11-x64.zip" format="html" scope="external">x64</xref>,
 							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.5-nts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
-						<li>PHP 5.5 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.5-zts-vc11-x64.zip" format="html" scope="external">x64</xref>, 
+						<li>PHP 5.5 VC11 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.5-zts-vc11-x64.zip" format="html" scope="external">x64</xref>,
 							<xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.5-zts-vc11-x86.zip" format="html" scope="external">x86</xref></li>
 						<li>PHP 5.4 VC9 NTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.4-nts-vc9-x86.zip" format="html" scope="external">x86</xref></li>
 						<li>PHP 5.4 VC9 ZTS - <xref href="http://sdk-snapshots.couchbase.com/php/php_couchbase-2.1.0-5.4-zts-vc9-x86.zip" format="html" scope="external">x86</xref></li>


### PR DESCRIPTION
@amarantha-k I've updated links for beta3, but unfortunately I do not have access to docs s3 bucket, could you extract this archive there?

[couchbase-php-client-2.2.0beta3.tar.gz](https://github.com/couchbase/docs-cb4/files/282267/couchbase-php-client-2.2.0beta3.tar.gz)
