### PR TITLE
Update Supported Platforms for 4.5

### DIFF
--- a/content/install/install-platforms.dita
+++ b/content/install/install-platforms.dita
@@ -131,7 +131,7 @@
 					</row>
 					<row>
 						<entry>Mac OSX</entry>
-						<entry>10.9 and 10.8</entry>
+						<entry>10.9 (Mavericks)</entry>
 						<entry>64 bit</entry>
 						<entry>Development and testing only </entry>
 					</row>


### PR DESCRIPTION
MAC 10.8 should be put into deprecated list and removed from supported platform list.