### PR TITLE
Added managing-cluster shared content + Go writeup

### DIFF
--- a/content/sdk/go/managing-cluster.dita
+++ b/content/sdk/go/managing-cluster.dita
@@ -1,22 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
-<concept id="concept_jk4_mhq_44">
- <title>Managing Clusters</title>
-  <shortdesc>You can manage Couchbase clusters programmatically through the <codeph>ClusterManager</codeph> interface
-    which is available through the <codeph>manager()</codeph> method of your <codeph>Cluster</codeph> object.</shortdesc>
- <conbody>
-   <section><title>Cluster Management</title>
-     <p></p>     
-     
-     
-   </section>
-   
-   <section><title>Bucket Management</title>
-     <p>Creating buckets and destorying buckets is performed, for example,  when running unit
-        tests.</p>     
-     
-     
-   </section>
-   
-  </conbody>
-</concept>
+<topic id="managing-cluster-go">
+  <title>Managing Clusters</title>
+  <body>
+        <p conref="../shared/flush-info-pars.dita#toplevel/management-intro"/>
+        <p>The Go SDK also comes with some convenience functionality for common Couchbase management requests.</p>
+        <p>Mangement operations in the Go SDK may be performed through several interfaces
+            depending on the object:<ul id="ul_scg_czl_2w">
+                <li><apiname>ClusterManager</apiname> class (obtained via <apiname>Cluster.Manager(usename, password string)</apiname>) (adminstrative username and password).</li>
+                <li><apiname>BucketManager</apiname> class (obtained
+                        via <apiname>Bucket.Manager(username, password string)</apiname>) (cluster or bucket credentials).</li>
+            </ul></p>
+
+        <section><title>Creating and Removing Buckets</title>
+            <p>The <apiname>ClusterManager</apiname> class may be used to create and delete buckets from the Couchbase cluster.
+            It is instantiated through the <apiname>Cluster</apiname>'s <apiname>Manager</apiname> method, providing the administrative username and password.</p>
+            <codeblock>myCluster, _ := gocb.Connect("couchbase://localhost")
+clusterManager = myCluster.Manager("Administrator", "123456")</codeblock>
+
+            </p><p>To create a bucket, use the <apiname>ClusterManager</apiname>'s <apiname>InsertBucket(settings *BucketSettings)</apiname> method. The <apiname>BucketSettings</apiname> struct is also used to expose information
+            about existing buckets (<apiname>ClusterManager.GetBuckets()</apiname> returns a slice of settings) or to update
+            an existing bucket (<apiname>ClusterManager.UpdateBucket(settings *BucketSettings)</apiname>).</p>
+
+            <note conref="../shared/flush-info-pars.dita#top-level/update-bucket-warning" />
+
+            <p>Only <parmname>name</parmname> and <parmname>type</parmname> parameters are mandatory for the <apiname>BucketSettings</apiname>. Here is the list of parameters available:</p>
+            <ul id="ul_ngw_cbm_2w">
+                <li><parmname>Name</parmname>: The name of the bucket (mandatory to create one, cannot be updated).</li>
+                <li><parmname>Type</parmname>: The type of the bucket (mandatory to create one, cannot be changed). Defaults to <codeph>BucketType.Couchbase</codeph>, but can also be <codeph>BucketType.Memcached</codeph> to create a cache bucket.</li>
+                <li><parmname>Quota</parmname>: How much memory should each node use for the bucket. This number is specified in megabytes.</li>
+                <li><parmname>Password</parmname>: If specified, makes this bucket password
+                    protected, forcing future connects (using the <apiname>Bucket</apiname>) class
+                    to specify the <parmname>password</parmname> parameter.</li>
+                <li><parmname>FlushEnabled</parmname>: Enables the
+                        <apiname>BucketManager#flush()</apiname> operation to be performed on this
+                    bucket (see the <xref href="#managing-cluster-go/flushing"/> section below).</li>
+                <li><parmname>Replicas</parmname>: The number of replicas to use for the bucket.</li>
+                <li><parmname>IndexReplicas</parmname>: Wether or not to replicate indexes.</li>
+            </ul>
+            <p>The following example updates an existing "hello" bucket (notice how all parameters are set):</p>
+            <codeblock>bucketSettings := BucketSettings {
+    FlushEnabled: true,
+    IndexReplicas: true,
+    Name: "hello",
+    Password: "",
+    Quota: 120,
+    Replicas: 1,
+    Type: BucketType.Couchbase
+}
+
+manager := cluster.Manager("Administrator", "123456")
+err := manager.UpdateBucket(bucketSettings)</codeblock>
+
+<!-- TODO if the Go SDK doesn't wait for the bucket to be ready, add the shared content on waiting/polling for bucket readiness -->
+
+            <p>Once you no longer need to use the bucket, you may delete the bucket using the
+                    <apiname>ClusterManager.RemoveBucket(name string)</apiname>
+                method:<codeblock>clusterManager.RemoveBucket("hello");</codeblock></p></section>
+
+        <section id="flushing">
+            <title>Flushing Buckets</title>
+            <p conref="../shared/flush-info-pars.dita#toplevel/flush-intro"/>
+            <p>You may flush a bucket in the Go SDK by using the
+                    <apiname>BucketManager.Flush()</apiname> method.</p>
+
+<!-- TODO paste a console output of what happens when a flush fails between the <screen> tags -->
+<!--            <p>The <apiname>flush</apiname> operation may fail if the bucket does not have flush
+                enabled:<screen>
+</screen></p>-->
+        </section>
+
+        <section>
+            <title>N1QL Index Management</title>
+            <p conref="../shared/flush-info-pars.dita#toplevel/index-management"/>
+            <p>You can manage indexes in the Go SDK using the <apiname>BucketManager</apiname>
+                class, with its various N1QL related methods: <apiname>GetIndexes()</apiname>, <apiname>CreateIndex(...)</apiname>, etc...</p>
+            <p>The following example creates a N1QL secondary index named "fooBar" on the "test" bucket,
+                indexing fields "foo" and "bar":</p>
+            <codeblock>myCluster, _ := gocb.Connect("couchbase://localhost")
+testBucket, _ := myCluster.OpenBucket("test")
+testManager := testBucket.BucketManager()
+
+//true, false at the end: ignore errors if the index exists, don't defer the creation
+testManager.CreateIndex("fooBar", string[]{ "foo", "bar" }, true, false);</codeblock>
+        </section>
+
+        <section>
+            <title>View Management</title>
+            <p conref="../shared/flush-info-pars.dita#toplevel/view-management"/>
+            <p> In the Go SDK, design documents are represented by the <codeph>DesignDocument</codeph>
+                and <codeph>View</codeph> structs. All operations on design documents are performed on
+                a <codeph>BucketManager</codeph> instance.</p>
+            <p>To inspect design documents, you can either retrieve them by name (<codeph>bucketManager.GetDesignDocument("landmarks")</codeph>) or iterate through a
+                slice of documents (<codeph>bucketManager.GetDesignDocuments()</codeph>).</p>
+            <p>To create or update design documents, use the <apiname>InsertDesignDocument(ddoc *DesignDocument)</apiname> and
+                <apiname>UpsertDesignDocument(ddoc *DesignDocument)</apiname> methods.</p>
+            <p>The following example inserts a design document with two regular views and one spatial
+				view into a bucket named <codeph>travel-sample</codeph>:</p>
+
+            <codeblock>//(note: obtaining the bucketManager is omitted in this snippet)
+// Initialize design document
+designDoc := DesignDocument {
+    Name: "landmarks",
+    Views: map[string]View {
+        "by_country": View {
+            Map: "function (doc, meta) { if (doc.type == 'landmark') { emit([doc.country, doc.city], null); } }",
+            Reduce: nil
+        },
+        "by_activity": View {
+            Map: "function (doc, meta) { if (doc.type == 'landmark') { emit(doc.activity, null); } }",
+            Reduce: "_count"
+        }
+    },
+    SpatialViews: map[string]View {
+        "by_coordinates": View {
+            Map: "function (doc, meta) { if (doc.type == 'landmark') { emit([doc.geo.lon, doc.geo.lat], null); } }",
+            Reduce: nil
+        }
+    }
+}
+
+// Insert design document into the bucket
+bucketManager.InsertDesignDocument(designDoc)</codeblock>
+
+            <note conref="../shared/flush-info-pars.dita#toplevel/one-view-update-warning"/>
+            <codeblock>//(note: obtaining the bucketManager is omitted in this snippet)
+// Get design document to be updated
+designDoc := bucketManager.GetDesignDocument("landmarks")
+
+// Update the "by_country" view, adding a reduce
+designDoc.Views["by_country"] := View { //reuse same name
+    Map: "function (doc, meta) { if (doc.type == 'landmark') { emit([doc.country, doc.city], null); } }", //same map function
+    Reduce: "_count" //added reduce function
+}
+
+// Resend to server
+bucketManager.UpsertDesignDocument(designDoc)</codeblock>
+            <p>To remove a design document from a bucket, pass its name to the <codeph>RemoveDesignDocument</codeph> method.</p>
+        </section>
+    </body>
+</topic>

--- a/content/sdk/java/managing-cluster.dita
+++ b/content/sdk/java/managing-cluster.dita
@@ -50,8 +50,8 @@ ClusterManager clusterManager = cluster.clusterManager("Administrator", "123456"
 
             </p><p>To create a bucket, use the <apiname>ClusterManager#insertBucket(BucketSettings)</apiname> method. The <apiname>BucketSettings</apiname> can be created via a builder, <apiname>DefaultBucketSettings.builder()</apiname>.
             This class is also used to expose information about an existing bucket (<apiname>ClusterManager#getBucket(string)</apiname>) or to update an existing bucket (<apiname>ClusterManager#updateBucket(BucketSettings)</apiname>).</p>
-            <note type="warning">Note that any property that is not explicitly set when building the <apiname>BucketSettings</apiname> will be using the default value. In the case of the update, this is not necessarily the currently configured value, so you should be careful to set all properties to their correct expected values when
-            updating an existing bucket configuration.</note>
+
+            <note conref="../shared/flush-info-pars.dita#top-level/update-bucket-warning" />
 
             <p>Only <parmname>name</parmname> and <parmname>type</parmname> parameters are mandatory for the <apiname>BucketSettings</apiname>. Here is the list of parameters available:</p><ul id="ul_ngw_cbm_2w">
                 <li><parmname>name</parmname>: The name of the bucket (mandatory to create one, cannot be updated).</li>
@@ -64,7 +64,7 @@ ClusterManager clusterManager = cluster.clusterManager("Administrator", "123456"
                         <apiname>BucketManager#flush()</apiname> operation to be performed on this
                     bucket (see the <xref href="#managing-cluster-java/flushing"/> section below).</li>
                 <li><parmname>replicas</parmname>: The number of replicas to use for the bucket.</li>
-                <li><parmname>indexReplicas</parmname>: The number of index replicas to use.</li>
+                <li><parmname>indexReplicas</parmname>: Wether or not to replicate indexes.</li>
                 <li><parmname>port</parmname>: The optional proxy port.</li>
             </ul>
             <p>The following example updates an existing "hello" bucket (notice how all parameters are set):</p>
@@ -113,13 +113,7 @@ testManager.createN1qlIndex("fooBar", ignoreIfExists, defer, "foo", "bar");
 
         <section>
             <title>View Management</title>
-            <p>Views are stored in design
-                documents. The SDK provides convenient methods to create, retrieve, and remove design
-                documents. To set up views, you create design documents that contain one or more view
-                definitions, and then insert the design documents into a bucket.</p>
-            <p>Each view in a design document is represented by a name and a set of MapReduce functions.
-                The mandatory map function describes how to select and transform the data from the bucket,
-                and the optional reduce function describes how to aggregate the results.</p>
+            <p conref="../shared/flush-info-pars.dita#toplevel/view-management"/>
             <p> In the Java SDK, design documents are represented by the <codeph>DesignDocument</codeph>
                 class and <codeph>View</codeph> interface. All operations on design documents are performed on
                 a <codeph>BucketManager</codeph> instance. Use the <codeph>DefaultView.create()</codeph> factory method to create a <apiname>View</apiname>.</p>
@@ -150,9 +144,8 @@ DesignDocument designDoc = DesignDocument.create(
 );
 // Insert design document into the bucket
 bucketManager.insertDesignDocument(designDoc);</codeblock>
-            <note type="warning">When you want to update an existing document with a new view (or a modification of a view's definition), you can use the <codeph>upsertDesignDocument</codeph> method.
-                <p>The catch is that this method needs the list of views in the document to be exhaustive, meaning that if you just create the new <codeph>View</codeph> definition as previously and add it to a new <codeph>DesignDocument</codeph> that you upsert, all your other views will be erased!</p>
-                <p>The solution is to perform a <codeph>getDesignDocument(ddoc)</codeph>, add your view definition to the DesignDocument's <codeph>views()</codeph> list, then upsert it. This also works with view modifications, provided the change is in the <codeph>map</codeph> or <codeph>reduce</codeph> functions (just reuse the same name for the modified <codeph>View</codeph>).</p></note>
+
+            <note conref="../shared/flush-info-pars.dita#toplevel/one-view-update-warning"/>
                 <codeblock>//(note: obtaining the bucketManager is omitted in this snippet)
 // Get design document to be updated
 DesignDocument designDoc = bucketManager.getDesignDocument("landmarks");

--- a/content/sdk/shared/flush-info-pars.dita
+++ b/content/sdk/shared/flush-info-pars.dita
@@ -7,25 +7,45 @@
             easy to use interface for adding, removing, monitoring and modfying buckets. In some
             instances you may wish to have a programmatic interface, for example if running as part
             of a setup script, or if setting up buckets for testing.</p>
-        <p id="after-creation">Once the bucket has been created, you must wait for it to become
+    <p id="after-creation">Once the bucket has been created, you must wait for it to become
             ready. This is because the bucket is actually created in the background. You may need to
             wait some time until the bucket becomes ready by repeatedly trying to connect to it,
             until it succeeds.</p>
-      <p id="flush-intro">When a bucket is flushed, all its content is removed. Because this
+    <note id="update-bucket-warning" type="warning">Note that any property that is not explicitly set when building the
+            <apiname>BucketSettings</apiname> will be using the default value. In the case of the update, this is
+            not necessarily the currently configured value, so you should be careful to set all properties to their
+            correct expected values when updating an existing bucket configuration.</note>
+    <p id="flush-intro">When a bucket is flushed, all its content is removed. Because this
             operation is dangerous it is disabled by default for each bucket. Bucket flusing may be
             useful in test environments where it becomes a simpler alternative to removing and
             creating a test bucket. You may enable bucket flushing on a per-bucket basis using the
             Couchbase Web Console or when creating a bucket.</p>
-      <p id="index-management">You can create and drop N1QL indexes using the SDK. This is
+    <p id="index-management">You can create and drop N1QL indexes using the SDK. This is
             especially useful when setting up new applications, or simply when ensuring that a given
             bucket has certain indexes defined. Indexes can be defined using actual N1QL statements
             or by using convenience functions within the SDK.</p>
-        <p id="ddoc-intro">You can create, delete, retrieve, and publish design documents (used for MapReduce views)
+    <p id="ddoc-intro">You can create, delete, retrieve, and publish design documents (used for MapReduce views)
             using the SDK. This is useful when setting up new applications, updating view
             definitions, or running tests.</p>
-      <note id="ddoc-async-warning">Management APIs are considered to be asynchronous, which means you may need to
-          wait some time (or poll manually) until the design document becomes available. This
-          is done by repeatedly querying the newly created view until it no longer fails with
-          a <i>not found</i> error.</note>
+    <note id="ddoc-async-warning">Management APIs are considered to be asynchronous, which means you may need to
+            wait some time (or poll manually) until the design document becomes available. This
+            is done by repeatedly querying the newly created view until it no longer fails with
+            a <i>not found</i> error.</note>
+    <p id="view-management">Views are stored in design
+            documents. The SDK provides convenient methods to create, retrieve, and remove design
+            documents. To set up views, you create design documents that contain one or more view
+            definitions, and then insert the design documents into a bucket.
+            Each view in a design document is represented by a name and a set of MapReduce functions.
+            The mandatory map function describes how to select and transform the data from the bucket,
+            and the optional reduce function describes how to aggregate the results.</p>
+    <note id="one-view-update-warning" type="warning">When you want to update an existing document with a new view (or a
+            modification of a view's definition), you can use the <codeph>upsertDesignDocument</codeph> method.
+        <p>The catch is that this method needs the list of views in the document to be exhaustive, meaning that if you just create
+            the new view definition as previously and add it to a new <codeph>DesignDocument</codeph> that you upsert, all your
+            other views will be erased!</p>
+        <p>The solution is to perform a <codeph>getDesignDocument</codeph>, add your view definition to the DesignDocument's
+            views list, then upsert it. This also works with view modifications, provided the change is in the
+            <codeph>map</codeph> or <codeph>reduce</codeph> functions (just reuse the same name for the modified
+            <codeph>View</codeph>), or for deletion of one out of several views in the document.</p></note>
   </body>
 </topic>


### PR DESCRIPTION
@brett19 please review Go part (especially TODOs and snippets).

Added shared notes and paragraphs for upserting a bucket setting, views, updating a single view.

If this is merged before #582 (node writeup), I'll update the node writeup.
Otherwise it will have to be modified in a second PR to integrate the shared content.