### PR TITLE
Release notes for Java 2.2.8 and fixed 2.2.7

### DIFF
--- a/content/sdks/java-2.2/documents-basics.dita
+++ b/content/sdks/java-2.2/documents-basics.dita
@@ -612,7 +612,7 @@ System.out.println(((User) found.content()).getUsername());]]></codeblock>
 	<dependency>
 		<groupId>com.couchbase.client</groupId>
 		<artifactId>java-client</artifactId>
-		<version>2.2.7</version>
+		<version>2.2.8</version>
 	</dependency>
 	<dependency>
 		<groupId>com.couchbase.client</groupId>

--- a/content/sdks/java-2.2/download-links.dita
+++ b/content/sdks/java-2.2/download-links.dita
@@ -9,7 +9,7 @@
 	<conbody>
 
 		<section>
-			<title>Current Release (2.2.7)</title>
+			<title>Current Release (2.2.8)</title>
 			<p>To use the Java SDK, point your application project object model (POM) to the library, which
 				is available on Maven Central. Here is a typical <filepath>pom.xml</filepath> that you
 				can copy and paste into your Java project:</p>
@@ -17,15 +17,20 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>java-client</artifactId>
-        <version>2.2.7</version>
+        <version>2.2.8</version>
     </dependency>
 </dependencies>
 ]]></codeblock>
 
 			<ul>
+				<li>2.2.8
+					<msgph outputclass="stable">GA</msgph>
+					<msgph outputclass="current">Current 2.2.x</msgph>
+					- <xref href="http://packages.couchbase.com/clients/java/2.2.8/Couchbase-Java-Client-2.2.8.zip" format="html" scope="external">Download</xref>
+					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-java-client-2.2.8/" format="html" scope="external">API Reference</xref>
+					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-core-io-1.2.9/" format="html" scope="external">Core API Reference (1.2.9)</xref></li>
 				<li>2.2.7
 					<msgph outputclass="stable">GA</msgph>
-					<msgph outputclass="current">CURRENT</msgph>
 					- <xref href="http://packages.couchbase.com/clients/java/2.2.7/Couchbase-Java-Client-2.2.7.zip" format="html" scope="external">Download</xref>
 					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-java-client-2.2.7/" format="html" scope="external">API Reference</xref>
 					| <xref href="http://docs.couchbase.com/sdk-api/couchbase-core-io-1.2.8/" format="html" scope="external">Core API Reference (1.2.8)</xref></li>

--- a/content/sdks/java-2.2/getting-started.dita
+++ b/content/sdks/java-2.2/getting-started.dita
@@ -21,7 +21,7 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>java-client</artifactId>
-        <version>2.2.7</version>
+        <version>2.2.8</version>
     </dependency>
 </dependencies>
 ]]></codeblock>

--- a/content/sdks/java-2.2/migrate.dita
+++ b/content/sdks/java-2.2/migrate.dita
@@ -60,7 +60,7 @@
     <dependency>
         <groupId>com.couchbase.client</groupId>
         <artifactId>java-client</artifactId>
-        <version>2.2.6</version>
+        <version>2.2.8</version>
     </dependency>
 </dependencies>
 ]]></codeblock>

--- a/content/sdks/java-2.2/release-notes.dita
+++ b/content/sdks/java-2.2/release-notes.dita
@@ -6,6 +6,29 @@
 
 		<conbody>
 			<section>
+				<title>Couchbase Java Client 2.2.8 GA (8 June 2016)</title>
+				<p>Version 2.2.8 is the eigth bugfix release of the 2.2 series. It brings bug fixes and enhancements.</p>
+			</section>
+
+			<section id="ga228-features">
+				<title>New features</title>
+				<p>This release contains the following enhancements:</p>
+				<ul>
+					<li>For this release, the associated <codeph>core-io</codeph> version is also one patch version ahead with <codeph>1.2.9</codeph>.</li>
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-961" format="html" scope="external">JCBC-961</xref>: In <codeph>ViewQuery</codeph>, the <codeph>isOrderRetained</codeph> getter is now public.</li>
+				</ul>
+			</section>
+
+			<section id="ga228-fixes">
+				<title>Fixed Issues</title>
+				<p>This release fixes the following issues:</p>
+				<ul>
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-340" format="html" scope="external">JVMCBC-340</xref>: Fix the keep alive messages not being sent anymore. This was due to a 2.2.6 change in Netty usage, saving allocations on writes but not trigerring the same kind of idle signals.</li>
+					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-339" format="html" scope="external">JVMCBC-339</xref>: Flush signals are only sent to non-null endpoints, guarding against potential NPEs.</li>
+				</ul>
+			</section>
+
+			<section>
 				<title>Couchbase Java Client 2.2.7 GA (6 May 2016)</title>
 				<p>Version 2.2.7 is the seventh bugfix release of the 2.2 series. It brings bug fixes and enhancements.</p>
 			</section>
@@ -18,6 +41,7 @@
 					<li><xref href="https://www.couchbase.com/issues/browse/JVMCBC-325" format="html" scope="external">JVMCBC-325</xref>
 					, <xref href="https://www.couchbase.com/issues/browse/JVMCBC-327" format="html" scope="external">JVMCBC-327</xref>:
 					All outgoing HTTP requests now have a HOST header.</li>
+					<li><xref href="https://www.couchbase.com/issues/browse/JCBC-952" format="html" scope="external">JCBC-952</xref>: The experimental Index Management API now has the "N1ql" word in all methods (like "<codeph>listN1qlIndexes()</codeph>") to allow future evolutions with different types of indexes. It can also create a secondary N1QL index with a WHERE clause.</li>
 				</ul>
 			</section>
 

--- a/content/sdks/java-2.2/tutorial3.dita
+++ b/content/sdks/java-2.2/tutorial3.dita
@@ -156,7 +156,7 @@ java -jar beersample-java2.jar]]></codeblock>
 		<dependency>
 			<groupId>com.couchbase.client</groupId>
 			<artifactId>java-client</artifactId>
-			<version>2.2.7</version>
+			<version>2.2.8</version>
 
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
The download-links doesn't list a CURRENT since it'll be supersed by 2.3.0
in a matter of days.

Added an item that was forgotten in 2.2.7's release notes.

pinging @ingenthron or @daschl for review :bow: