### PR TITLE
managing-cluster: fix go and share content in node

### DIFF
--- a/content/sdk/go/managing-cluster.dita
+++ b/content/sdk/go/managing-cluster.dita
@@ -7,15 +7,16 @@
         <p>The Go SDK also comes with some convenience functionality for common Couchbase management requests.</p>
         <p>Mangement operations in the Go SDK may be performed through several interfaces
             depending on the object:<ul id="ul_scg_czl_2w">
-                <li><apiname>ClusterManager</apiname> class (obtained via <apiname>Cluster.Manager(usename, password string)</apiname>) (adminstrative username and password).</li>
-                <li><apiname>BucketManager</apiname> class (obtained
+                <li><apiname>ClusterManager</apiname> interface (obtained via <apiname>Cluster.Manager(usename, password string)</apiname>) (adminstrative username and password).</li>
+                <li><apiname>BucketManager</apiname> interface (obtained
                         via <apiname>Bucket.Manager(username, password string)</apiname>) (cluster or bucket credentials).</li>
             </ul></p>
 
         <section id="go-creating-and-removing-buckets">
             <title>Creating and Removing Buckets</title>
-            <p>The <apiname>ClusterManager</apiname> class may be used to create and delete buckets from the Couchbase cluster.
-            It is instantiated through the <apiname>Cluster</apiname>'s <apiname>Manager</apiname> method, providing the administrative username and password.</p>
+            <p>The <apiname>ClusterManager</apiname> interface may be used to create and delete buckets from the Couchbase
+            cluster. It is instantiated through the <apiname>Cluster</apiname>'s <apiname>Manager</apiname> method, providing the
+            administrative username and password.</p>
             <codeblock>myCluster, _ := gocb.Connect("couchbase://localhost")
 clusterManager = myCluster.Manager("Administrator", "123456")</codeblock>
             <p>To create a bucket, use the <apiname>ClusterManager</apiname>'s <apiname>InsertBucket(settings *BucketSettings)</apiname> method. The <apiname>BucketSettings</apiname> struct is also used to expose information
@@ -30,7 +31,7 @@ clusterManager = myCluster.Manager("Administrator", "123456")</codeblock>
                 <li><parmname>Type</parmname>: The type of the bucket (mandatory to create one, cannot be changed). Defaults to <codeph>BucketType.Couchbase</codeph>, but can also be <codeph>BucketType.Memcached</codeph> to create a cache bucket.</li>
                 <li><parmname>Quota</parmname>: How much memory should each node use for the bucket. This number is specified in megabytes.</li>
                 <li><parmname>Password</parmname>: If specified, makes this bucket password
-                    protected, forcing future connects (using the <apiname>Bucket</apiname>) class
+                    protected, forcing future connects (using the <apiname>Bucket</apiname>) interface
                     to specify the <parmname>password</parmname> parameter.</li>
                 <li><parmname>FlushEnabled</parmname>: Enables the
                         <apiname>BucketManager#flush()</apiname> operation to be performed on this
@@ -52,8 +53,6 @@ clusterManager = myCluster.Manager("Administrator", "123456")</codeblock>
 manager := cluster.Manager("Administrator", "123456")
 err := manager.UpdateBucket(bucketSettings)</codeblock>
 
-<!-- TODO if the Go SDK doesn't wait for the bucket to be ready, add the shared content on waiting/polling for bucket readiness -->
-
             <p>Once you no longer need to use the bucket, you may delete the bucket using the
                     <apiname>ClusterManager.RemoveBucket(name string)</apiname>
                 method:<codeblock>clusterManager.RemoveBucket("hello");</codeblock></p></section>
@@ -63,16 +62,16 @@ err := manager.UpdateBucket(bucketSettings)</codeblock>
             <p>You may flush a bucket in the Go SDK by using the
                     <apiname>BucketManager.Flush()</apiname> method.</p>
 
-<!-- TODO paste a console output of what happens when a flush fails between the <screen> tags -->
-<!--            <p>The <apiname>flush</apiname> operation may fail if the bucket does not have flush
-                enabled:<screen>
-</screen></p>-->
+            <p>The <apiname>flush</apiname> operation may fail if the bucket does not have flush
+                enabled:<screen>{
+  "_": "Flush is disabled for the bucket"
+}</screen></p>
         </section>
         <section id="go-index-management">
             <title>Index Management</title>
             <p conref="../shared/flush-info-pars.dita#toplevel/index-management"/>
             <p>You can manage indexes in the Go SDK using the <apiname>BucketManager</apiname>
-                class, with its various N1QL related methods: <apiname>GetIndexes()</apiname>, <apiname>CreateIndex(...)</apiname>, etc...</p>
+                interface, with its various N1QL related methods: <apiname>GetIndexes()</apiname>, <apiname>CreateIndex(...)</apiname>, etc...</p>
             <p>The following example creates a N1QL secondary index named "fooBar" on the "test" bucket,
                 indexing fields "foo" and "bar":</p>
             <codeblock>myCluster, _ := gocb.Connect("couchbase://localhost")

--- a/content/sdk/nodejs/managing-cluster.dita
+++ b/content/sdk/nodejs/managing-cluster.dita
@@ -35,7 +35,7 @@
                 (using the <apiname>Bucket</apiname>) to specify the <parmname>password</parmname> parameter. Must be
                 used together with the <parmname>authType: 'sasl'</parmname> (which is the default).</li>
             <li><parmname>flushEnabled</parmname>: Enables the <apiname>BucketManager#flush()</apiname> operation to be performed
-                on this bucket (see the <xref href="#managing-cluster-node/flushing"/> section below).</li>
+                on this bucket (see the <xref href="#managing-cluster-node/node-flushing"/> section below).</li>
             <li><parmname>replicaNumber</parmname>: The number of replicas to use for the bucket.</li>
             <li><parmname>replicaIndex</parmname>: Wether or not to replicate indexes.</li>
         </ul>
@@ -54,7 +54,7 @@ manager.createBucket("hello", { flushEnabled: true }, function(err) {
     console.log('Could not delete hello bucket: ', err);
 });</codeblock></p></section>
 
-    <section id="flushing">
+    <section id="node-flushing">
         <title>Flushing Buckets</title>
         <p conref="../shared/flush-info-pars.dita#toplevel/flush-intro"/>
         <p>You may flush a bucket in the Node SDK by using the <apiname>BucketManager</apiname>'s
@@ -80,15 +80,9 @@ bucketMgr.flush(function(err, status) {
     <!--</section>-->
 
 
-    <section>
+    <section id="node-view-management">
         <title>View Management</title>
-        <p>Views are stored in design documents. The SDK provides convenient methods to create, retrieve, and remove
-            design documents. To set up views, you create design documents that contain one or more view definitions, and then
-            insert the design documents into a bucket.</p>
-        <p>Each view in a design document is represented by a name and a set of MapReduce functions.
-            The mandatory map function describes how to select and transform the data from the bucket,
-            and the optional reduce function describes how to aggregate the results.</p>
-<!-- TODO use shared content when available instead of paragraphs above -->
+        <p conref="../shared/flush-info-pars.dita#toplevel/view-management"/>
         <p>To create a view, you can use the <codeph>manager()</codeph> method of your bucket instance to retrieve a
           <codeph>BucketManager</codeph> instance. After you have a <codeph>BucketManager</codeph> instance, invoke the
           <codeph>upsertDesignDocument</codeph> method to store the design document for later querying.</p>
@@ -143,11 +137,7 @@ map: function(doc, meta) {
 }
 };</codeblock>
 
-        <note type="warning">When you want to update an existing document to either introduce a new view, modify an existing
-            view or delete an existing view, you can use the <codeph>upsertDesignDocument</codeph> method.
-            <p>The catch is that this method needs the list of views in the document to be exhaustive, meaning that if you just create the new <codeph>View</codeph> definition as previously and add it to a new <codeph>DesignDocument</codeph> that you upsert, all your other views will be erased!</p>
-            <p>The solution is to perform a <codeph>getDesignDocument(ddoc)</codeph>, add your view definition to the DesignDocument's <codeph>views()</codeph> list, then upsert it. This also works with view modifications, provided the change is in the <codeph>map</codeph> or <codeph>reduce</codeph> functions (just reuse the same name for the modified <codeph>View</codeph>).</p></note>
-
+            <note conref="../shared/flush-info-pars.dita#toplevel/one-view-update-warning"/>
             <p>Here is an example of deleting a view from an existing document, which follows the same principle:</p>
             <codeblock>var bucket = cluster.openBucket();
 var bucketMgr = bucket.manager();


### PR DESCRIPTION
follow-up to #586 @brett19 I removed the mentions of classes in favor of interfaces in Go. I also used the shared content paragraphs in the node writeup.