### PR TITLE
added links, fleshed out and reorg 1 section in shared fts content

### DIFF
--- a/content/n1ql/n1ql-intro/queriesandresults.dita
+++ b/content/n1ql/n1ql-intro/queriesandresults.dita
@@ -52,7 +52,7 @@
 }			</codeblock>
 		</section>
 
-		<section>
+		<section id="paths">
 			<title>Paths</title>
 			<p>N1QL provides <term>paths</term> to support nested data. Paths use dot notation syntax
 				to identify the logical location of an attribute within a document. For example, to get

--- a/content/sdk/full-text-search-overview.dita
+++ b/content/sdk/full-text-search-overview.dita
@@ -99,6 +99,9 @@ Found in document ID=landmark_15133. Score=0.81847489864</screen><p>The
             <p>Once you've created your index, your can query it by using the methods above,
                 replacing <codeph>travel-search</codeph> with the name you used to create the
                 index.</p>
+            <p>To learn more about making your buckets searchable, see the
+                <xref href="../fts/fts-creating-indexes.dita#topic_ksl_wwk_1v"/> section of the
+                full text search documentation.</p>
         </section>
         <section><title>Query Types</title><p>The query executed in the previous section is called a
                     <i>string query</i>. This type of query searches for terms based on a special
@@ -106,8 +109,9 @@ Found in document ID=landmark_15133. Score=0.81847489864</screen><p>The
                     -country:france</codeph> will match documents which contain <i>cheese</i> in
                 their <codeph>description</codeph> field, but are <i>not</i> located in France.
                 String queries are ideal for searchbox fields to allow users to provide more
-                specialized query criteria. You can read more about the query string syntax [TODO:
-                LINK]</p><p>There are many other query types available. These query types differ
+                specialized query criteria. You can read more about the <xref href="../fts/fts-query-types.dita#topic_jfq_fn4_1v/query-string-query-syntax">Query String syntax</xref>
+                in the full text search documentation.</p>
+                <p>There are many other query types available. These query types differ
                 primarily in how they interpret the search term: whether it is treated as a phrase,
                 a word, an exact match, or a prefix: A <term>Match</term> query searches for the
                 input text within documents and is the simplest of queries. <term>Match
@@ -148,7 +152,8 @@ for r in results:
     public_likes dict_keys(['christop'])</screen>As
                 can be seen in the above examples, the <term>Term</term> assumes the search input is
                 an actual term to search for (<codeph>ch</codeph>) and therefore rejects things such
-                as <codeph>chose</codeph>, <codeph>chairs</codeph> and similar.</p></section>
+                as <codeph>chose</codeph>, <codeph>chairs</codeph> and similar.</p>
+            </section>
         <section>
             <title>Compound Queries</title>
             <p>You can compose queries made of other queries. You can use a <term>Conjunction</term>
@@ -187,6 +192,16 @@ ID landmark_40690
                 other subqueries, affecting the ordering.</p>
         </section>
         <section>
+            <title>Other Query Types</title>
+            <p>There are other query types you can use, such as <term>Date Range</term> and
+                    <term>Numeric Range</term> queries which match documents matching a certain time
+                span or value range. There are also debugging queries such as <term>Term</term> and
+                    <term>Phrase</term> queries which perform exact queries (without any
+                analysis).</p>
+            <p>For a quick overview of all the available query types, see the <xref href="../fts/fts-query-types.dita#topic_jfq_fn4_1v"/>
+                section of the full text search documentation.</p>
+        </section>
+        <section>
             <title>Query Options</title>
             <p>You can specify query options to modify how the search term is treated. This section
                 will enumerate some common query options and how they affect query results.<ul
@@ -217,8 +232,9 @@ ID landmark_40690
                         query. Search results are always ordered by score, with highest-scored hits
                         appearing first.</li>
                     <li><parmname>locations</parmname>: A JSON object containing information about
-                        each match in the document. Its keys are <i>document paths</i>[TODO: XREF
-                        N1QL/subdoc paths] where matches may be found, and its values are arrays
+                        each match in the document. Its keys are <i>document paths</i> (in the
+                        <xref href="../n1ql/n1ql-intro/queriesandresults.dita#topic_1_2/paths">N1QL sense</xref>)
+                        where matches may be found, and its values are arrays
                         that contain the <i>match location</i>. The <i>match location</i> is a JSON
                         object whose keys are the matched terms found, and whose values are
                             <i>locations</i>:<ul id="ul_e3w_hcz_bw">
@@ -234,8 +250,9 @@ ID landmark_40690
                                 third word in the field.</li>
                         </ul></li>
                 </ul></p>
-            <p>Couchbase SDKs may abstract some of the fields or provide wrapper methods around
-                them.</p>
+            <p>To learn more about the response format used by the FTS service, see the
+                <xref href="../fts/fts-response-object-schema.dita#topic_uvg_4x1_4v"/> section of the full text search documentation.
+                Couchbase SDKs may abstract some of the fields or provide wrapper methods around them.</p>
         </section>
         <section>
             <title id="facets">Aggregation and Statistics (Facets)</title>
@@ -262,20 +279,18 @@ pprint(results.facets['terms'])</codeblock><screen>{'field': 'description',
             <p>You can likewise use a <i>Date Range Facet</i> to count the number of results by
                 their age, and <i>Numeric Range Facet</i> to count results using an arbitrary
                 numeric range.</p>
+            <p>To learn more about facets, see the <xref href="../fts/fts-search-facets.dita#topic_cjj_ks4_1v"/>
+                section of the full text search documentation.</p>
         </section>
         <section>
             <title>Partial Search Results</title>
-            <p>Because FTS queries use <i>pindexes</i>[TODO], you may encounter situations where
-                some results may be unavailable if some pindex nodes are not online... [TODO: I
-                don't know what to write here..]</p>
-        </section>
-        <section>
-            <title>Other Query Types</title>
-            <p>There are other query types you can use, such as <term>Date Range</term> and
-                    <term>Numeric Range</term> queries which match documents matching a certain time
-                span or value range. There are also debugging queries such as <term>Term</term> and
-                    <term>Phrase</term> queries which perform exact queries (without any
-                analysis).</p>
+            <p>The FTS service splits the indexing data between several <i>pindexes</i>. Because of that,
+                you may encounter situations where only a subset of the pindexes could provide results
+                (eg. if some pindex nodes are not online...).</p>
+            <p>What happens in this case is that FTS returns a list of <i>partial</i> results, and notifies
+                you that one or several <i>errors</i> also hapened. You can inspect the errors, which will each
+                correspond to an failing pindex, via the SDK. Of course, the partial results (the result from
+                healthy pindexes) are still available through the usual methods in the SDK result representation.</p>
         </section>
     </body>
 </topic>


### PR DESCRIPTION
@ingenthron @mnunberg I moved the "Other types of queries" closer to where we describe queries.

Also I added a link to N1QL's documentation on paths, so I had to set an id for this particular section. If it's not ok to do so, the id change can be removed and the link edited accordingly (the doc is small enough that finding the path part should not be too much of a problem).