### PR TITLE
Review managing-connections, harmonized shortdesc

### DIFF
--- a/content/sdk/c/lcb-pars-shared.dita
+++ b/content/sdk/c/lcb-pars-shared.dita
@@ -4,8 +4,8 @@
   <title>No Title For Paragraph Partials</title>
   <body>
     <p id="connstr-intro"> You can specify additional options when connecting to the cluster by
-      using the <i>connection string</i>. The connection string indicates to the client where
-      cluster nodes may be found and how to connect to them. The <i>connection string</i> is common
+      using the <i>connection string</i>. It indicates to the client where
+      cluster nodes may be found and how to connect to them. Note that it is common
       to other Couchbase SDKs as well as the <xref
         href="../webui-cli-access.dita#concept_j3z_zhm_zs">command-line client</xref>. The
         <i>connection string</i> uses a URI-like format familiar to what is used in other database

--- a/content/sdk/c/managing-connections.dita
+++ b/content/sdk/c/managing-connections.dita
@@ -2,9 +2,11 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "generalTask.dtd">
 <concept id="toplevel">
  <title>Managing Connections</title>
+    <shortdesc>This section describes how to connect the C SDK to a Couchbase cluster and bucket. It contains best
+        practices as well as information on the connection string,  SSL and other advanced connection options.</shortdesc>
     <conbody>
-        
-        
+
+
         <section>
             <title>Creating a handle</title>
             <p>A library handle is created using the <apiname>lcb_create()</apiname> function which
@@ -110,7 +112,7 @@ if (rc != LCB_SUCCESS) {
                 handling cluster topology changes.<note>You are not required to enumerate or pass
                     all Couchbase cluster nodes to the client. The client only needs to know about a
                         <i>single</i> node which is a member of the cluster. Once the client has
-                    connected to the node, it will query that node about the clustet topology, which
+                    connected to the node, it will query that node about the cluster topology, which
                     in turn contains information about all Couchbase nodes and the services they
                     contain.</note></p>
         </section>

--- a/content/sdk/dotnet/managing-connections.dita
+++ b/content/sdk/dotnet/managing-connections.dita
@@ -3,7 +3,8 @@
   PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="concept2677">
   <title>Managing Connections</title>
-  <shortdesc>Shows how to instantiate a client object to connect to a Couchbase cluster</shortdesc>
+  <shortdesc>This section describes how to connect the .NET SDK to a Couchbase cluster and bucket. It contains best
+      practices as well as information on the connection string,  SSL and other advanced connection options.</shortdesc>
   <conbody>
     <section>
       <title>Connecting to a Bucket</title>

--- a/content/sdk/go/managing-connections.dita
+++ b/content/sdk/go/managing-connections.dita
@@ -2,9 +2,9 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="concept_ppz_lhq_44">
  <title>Managing Connections </title>
-    <shortdesc>This page describes connecting to Couchbase cluster and bucket. It contains best
-        practices as well as information on advanced connection options.</shortdesc>
-	
+    <shortdesc>This section describes how to connect the Go SDK to a Couchbase cluster and bucket. It contains best
+        practices as well as information on the connection string,  SSL and other advanced connection options.</shortdesc>
+
 <conbody>
         <section><title>Creating a Cluster Object</title>The <apiname>Cluster</apiname> object
             serves as an organizational unit for any <apiname>Bucket</apiname> objects created. As
@@ -43,11 +43,11 @@ protectedBucket, err := cluster.openBucket("protected", "s3cr3t")</codeblock>
                     <apiname>Bucket.Close()</apiname> call on the bucket, which will disconnect your
                 application from the given bucket.</p>
         </section>
-	
+
 	<section id="ssl">
-		
+
 		<title>Configuring SSL</title>
-		
+
 		<p><hazardstatement>
                     <messagepanel id="messagepanel_ch1_l5p_fw">
                         <typeofhazard>SSL Verification not implemented in Go SDK</typeofhazard>
@@ -61,8 +61,8 @@ protectedBucket, err := cluster.openBucket("protected", "s3cr3t")</codeblock>
 		<codeblock outputclass="language-go">myCluster, _ := gocb.Connect("couchbases://10.1.1.1")
 myBucket, _ := myCluster.OpenBucket("default", "")</codeblock>
 	</section>
-	
-	
+
+
 </conbody>
- 
+
 </concept>

--- a/content/sdk/java/managing-connections.dita
+++ b/content/sdk/java/managing-connections.dita
@@ -3,7 +3,8 @@
   PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="concept2677">
 	<title>Managing Connections</title>
-	<shortdesc>Shows how to instantiate a client object to connect to a Couchbase cluster</shortdesc>
+    <shortdesc>This section describes how to connect the Java SDK to a Couchbase cluster and bucket. It contains best
+        practices as well as information on SSL and other advanced connection options.</shortdesc>
 	<conbody>
 		<section>
 			<title>Connecting to a Bucket</title>

--- a/content/sdk/nodejs/managing-connections.dita
+++ b/content/sdk/nodejs/managing-connections.dita
@@ -2,6 +2,8 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="concept_ppz_lhq_44">
     <title>Managing Connections</title>
+    <shortdesc>This section describes how to connect the Node.JS SDK to a Couchbase cluster and bucket. It contains best
+        practices as well as information on the connection string,  SSL and other advanced connection options.</shortdesc>
     <conbody>
         <p> You can specify additional options when connecting to the cluster by using the
                 <i>connection string</i>. The connection string indicates to the client where

--- a/content/sdk/php/managing-connections.dita
+++ b/content/sdk/php/managing-connections.dita
@@ -2,6 +2,8 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="managing-connections-php">
  <title>Managing Connections </title>
+ <shortdesc>This section describes how to connect the PHP SDK to a Couchbase cluster and bucket. It contains best
+     practices as well as information on the connection string,  SSL and other advanced connection options.</shortdesc>
 <body>
 	<p>To manage Couchbase Server connections, you need to configure the client, connect to a bucket,
 			and configure SSL.</p>

--- a/content/sdk/python/managing-connections.dita
+++ b/content/sdk/python/managing-connections.dita
@@ -2,6 +2,8 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="concept_ppz_lhq_44">
     <title>Managing Connections</title>
+    <shortdesc>This section describes how to connect the Python SDK to a Couchbase cluster and bucket. It contains best
+        practices as well as information on the connection string,  SSL and other advanced connection options.</shortdesc>
     <conbody>
         <p conref="../c/lcb-pars-shared.dita#toplevel/connstr-intro"/>
         <section>


### PR DESCRIPTION
cc. @ingenthron @mnunberg

This change stems from a review of the content for Python's managing-connections.dita

Fixes a typo in shared content, harmonizes the shortdesc for all SDKs and reworded the connection string shared intro a bit.