### PR TITLE
Use shared content for most SDKs failure-considerations

### DIFF
--- a/content/sdk/dotnet/failure-considerations.dita
+++ b/content/sdk/dotnet/failure-considerations.dita
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_abk_bbn_bw">
-  <title>Failure Considerations</title>
-  <body>
-    <p>TODO</p>
-  </body>
+    <title>Failure Considerations</title>
+    <shortdesc conref="../shared/env-errors.dita#toplevel/shortdesc"/>
+    <body>
+        <section conref="../shared/env-errors.dita#toplevel/begin"
+              conrefend="../shared/env-errors.dita#toplevel/end"/>
+    </body>
 </topic>

--- a/content/sdk/go/failure-considerations.dita
+++ b/content/sdk/go/failure-considerations.dita
@@ -2,4 +2,9 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_wxg_cwb_mv" conref="../shared/env-errors.dita">
     <title>Failure Considerations</title>
+    <shortdesc conref="../shared/env-errors.dita#toplevel/shortdesc"/>
+    <body>
+        <section conref="../shared/env-errors.dita#toplevel/begin"
+              conrefend="../shared/env-errors.dita#toplevel/end"/>
+    </body>
 </topic>

--- a/content/sdk/java/failure-considerations.dita
+++ b/content/sdk/java/failure-considerations.dita
@@ -2,7 +2,9 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_ubw_tbv_xv">
   <title>Failure Considerations</title>
+  <shortdesc conref="../shared/env-errors.dita#toplevel/shortdesc"/>
   <body>
-    <p>TBD</p>
+      <section conref="../shared/env-errors.dita#toplevel/begin"
+            conrefend="../shared/env-errors.dita#toplevel/end"/>
   </body>
 </topic>

--- a/content/sdk/nodejs/failure-considerations.dita
+++ b/content/sdk/nodejs/failure-considerations.dita
@@ -2,4 +2,9 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_wxg_cwb_mv" conref="../shared/env-errors.dita">
     <title>Failure Considerations</title>
+    <shortdesc conref="../shared/env-errors.dita#toplevel/shortdesc"/>
+    <body>
+        <section conref="../shared/env-errors.dita#toplevel/begin"
+              conrefend="../shared/env-errors.dita#toplevel/end"/>
+    </body>
 </topic>

--- a/content/sdk/php/failure-considerations.dita
+++ b/content/sdk/php/failure-considerations.dita
@@ -2,4 +2,9 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_wxg_cwb_mv" conref="../shared/env-errors.dita">
     <title>Failure Considerations</title>
+    <shortdesc conref="../shared/env-errors.dita#toplevel/shortdesc"/>
+    <body>
+        <section conref="../shared/env-errors.dita#toplevel/begin"
+              conrefend="../shared/env-errors.dita#toplevel/end"/>
+    </body>
 </topic>

--- a/content/sdk/python/failure-considerations.dita
+++ b/content/sdk/python/failure-considerations.dita
@@ -2,4 +2,9 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_wxg_cwb_mv" conref="../shared/env-errors.dita">
     <title>Failure Considerations</title>
+    <shortdesc conref="../shared/env-errors.dita#toplevel/shortdesc"/>
+    <body>
+        <section conref="../shared/env-errors.dita#toplevel/begin"
+              conrefend="../shared/env-errors.dita#toplevel/end"/>
+    </body>
 </topic>


### PR DESCRIPTION
All SDKs (except C which has an additional writeup) now simply import env-errors from the shared content as their `failure-considerations` topic.

@ingenthron @mnunberg please check. Did this after reading https://trello.com/c/2yUZh51d and seeing that most of theses topics were empty.