### PR TITLE
DOC-1455

### DIFF
--- a/content/cli/cbbackup-tool.dita
+++ b/content/cli/cbbackup-tool.dita
@@ -34,9 +34,9 @@ cbbackup couchbase://HOST:8091 /backup-43 [-m diff] --single-node -u Administrat
 cbbackup couchbase://HOST:8091 /backup-43 [-m diff] --single-node -u Administrator -p password  
 cbbackup couchbase://HOST:8091 /backup-43 [-m accu] --single-node -u Administrator -p password </codeblock>
          
-         <note type="note">After backing up and restoring a cluster, be sure to rebuild your
+    <!--     <note type="note">After backing up and restoring a cluster, be sure to rebuild your
             indexes. <p>See <xref href="../indexes/indexing-overview.dita#concept_ssb_qhb_ys"/>for
-               more information. </p></note>
+               more information. </p></note> -->
          <p>Syntax example of a full backup plus two differentials and one accumulative for a single node.</p>
          
          <codeblock>cbbackup couchbase://HOST:8091 /backup-43 [-m full] --single-node -u Administrator -p password \  


### PR DESCRIPTION
removed note about recreating indexes after using cbbackup. See #MB-15168