### PR TITLE
DOC-1618: Fix broken link to CAS

### DIFF
--- a/content/sdk/c.ditamap
+++ b/content/sdk/c.ditamap
@@ -2,11 +2,11 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
 	<title>C SDK Guide</title>
-    <keydef keys="lcb-api-link" href="http://docs.couchbase.com/sdk-api/couchbase-c-client-2.6.1" format="html"/>
+    <keydef keys="lcb-api-link" href="http://docs.couchbase.com/sdk-api/couchbase-c-client-2.6.2" format="html"/>
     <keydef keys="lcb-current-version">
         <topicmeta>
             <keywords>
-                <keyword>2.6.1</keyword>
+                <keyword>2.6.2</keyword>
             </keywords>
         </topicmeta>
     </keydef>

--- a/content/sdk/nonjson.dita
+++ b/content/sdk/nonjson.dita
@@ -18,7 +18,7 @@
             application which is using a customized binary format.</p>
         <p>Note that only JSON documents can be accessed using Query (N1QL). Limited support for
             non-JSON documents is available for MapReduce views. Additionally, non-JSON documents
-            will not be accessible using the <xref href="http://developer.couchbase.com/documentation/server/current/developer-guide/webui.html" format="html" scope="external">Web
+            will not be accessible using the <xref href="webui-cli-access.dita">Web
                 UI</xref> (the contents will be shown in their Base64 equivalent).</p>
         <section>
             <title>Using non-JSON documents</title>

--- a/content/sdk/shared/couchbase-errors.dita
+++ b/content/sdk/shared/couchbase-errors.dita
@@ -29,7 +29,7 @@
                 example indicating that a new account could not be registered with the given user
                 name, since it already exists.</p>
             <p><b>CAS Mismatch</b></p>
-            <p>A <xref href="http://developer.couchbase.com/documentation/server/4.5/developer-guide/cas-concurrency.html" format="html" scope="external">CAS</xref> mismatch error is
+            <p>A <xref href="../concurrent-mutations-cluster.dita">CAS</xref> mismatch error is
                 returned when an operation was executed with a CAS value (supplied by the
                 application) and the CAS value passed differs from the CAS value on the server. The
                 corrective course of action in this case is for the application to re-try the


### PR DESCRIPTION
Also fixed another instance where it seems we've embedded an http://
link which could've been replaced by a direct DITA reference.