### PR TITLE
DOC-1406: Clarify how ttl handles time

### DIFF
--- a/content/sdk/core-operations.dita
+++ b/content/sdk/core-operations.dita
@@ -326,16 +326,19 @@ print repr(cb.get('binary_doc').value)</codeblock>Note
                 issues when the intended offset is larger than 30 days, in which case it is taken to
                 mean a Unix time stamp and, as a result,  the document will expire automatically as
                 soon as it is stored.</p>
-            <hazardstatement type="remember">
-                <messagepanel id="messagepanel_y22_jqs_zs">
-                    <typeofhazard>If you wish to use the expiry feature, then you should supply the
-                        expiry value for every mutation operation</typeofhazard>
-                    <howtoavoid>When dealing with expiration, it is important to note that most
+            <note type="remember">
+                <ul>
+                    <li>If you wish to use the expiry feature, then you should supply the
+                        expiry value for every mutation operation.</li>
+                    <li>When dealing with expiration, it is important to note that most
                         operations will implicitly remove any existing expiration. Thus, when
                         modifying a document with expiration, it is important to pass the desired
-                        expiration time.</howtoavoid>
-                </messagepanel>
-            </hazardstatement>
+                        expiration time.</li>
+                    <li>A document is expired as soon as the current time on the Couchbase Server node responsible
+                    for the document exceeds the expiration value. Bear this in mind in situations where the time on your application servers
+                    differs from the time on your Couchbase Server nodes.</li>
+                </ul>
+            </note>
             <p>Note that expired documents are not deleted from the server as soon as they expire.
                 While a request to the server for an expired document will receive a response
                 indicating the document does not exist, expired documents are actually deleted (i.e.


### PR DESCRIPTION
For some reason we used a 'hazardstatement' on this page, this renders to a 'Remember' note on our main site so I just changed the element the information was stored in. This was so that I could add a third note to this section.

Will need to be backported to 4.5 when approved.