### PR TITLE
Remove empty codeblock from delete example section

### DIFF
--- a/content/rest-api/rbac.dita
+++ b/content/rest-api/rbac.dita
@@ -109,8 +109,7 @@
     <dl>
       <dlentry>
         <dt>Delete users</dt>
-        <dd><codeblock></codeblock>
-          <codeblock>DELETE /settings/rbac/users/&lt;user_id&gt;</codeblock>
+        <dd><codeblock>DELETE /settings/rbac/users/&lt;user_id&gt;</codeblock>
         </dd>
         <dd>In this example, Alice Smith was deleted as the Replication Administrator and the other
             user, John Doe, remains as a Cluster administrator.


### PR DESCRIPTION
Removes empty code block from RBAC delete user example