### PR TITLE
Correct Python version.

### DIFF
--- a/content/dev-guide.ditamap
+++ b/content/dev-guide.ditamap
@@ -9,7 +9,6 @@
     <mapref href="sdk/nodejs.ditamap"/>
    </topichead>
    <topichead navtitle="Java;Version 2.3">
-    <!-- TODO: remove the above example of the future -->
     <mapref href="sdk/java.ditamap"/>
    </topichead>
    <topichead navtitle=".NET;Version 2.3">
@@ -18,7 +17,7 @@
    <topichead navtitle="PHP;Version 2.2">
     <mapref href="sdk/php.ditamap"/>
    </topichead>
-   <topichead navtitle="Python;Version 2.3">
+   <topichead navtitle="Python;Version 2.1">
     <mapref href="sdk/python.ditamap"/>
    </topichead>
    <topichead navtitle="Go;Version 1.1">


### PR DESCRIPTION
When doing the 4.6 update on versions, I noted the Python version
was incorrect.  It's apparently been this way for some time.