### PR TITLE
Gts 0001c

### DIFF
--- a/content/getting-started/look-at-the-results.dita
+++ b/content/getting-started/look-at-the-results.dita
@@ -168,7 +168,7 @@
 				Now that you have a basic familiarity with the way in which Couchbase Server organizes data, you can
 				start to define and execute <i>queries</i>, in order to return specific data-subsets. You'll experiment 
 				with this in the next section, 
-				<xref href="./try-a-query.dita" scope="local" format="dita">Try a Query</xref>. 
+				<xref href="./try-a-query.dita" scope="local" format="dita">Run Your First N1QL Query</xref>. 
 			</p>
 			
 		</section>

--- a/content/getting-started/run-hello-world.dita
+++ b/content/getting-started/run-hello-world.dita
@@ -313,7 +313,7 @@ myBucket.query(queryTemplate, [countryValueString],
 				Couchbase documentation-set: and in the final stage of this <i>Getting Started</i>
 				sequence, 
 				<xref href="./choose-your-next-steps.dita" scope="local" format="dita">Choose Your Next Steps</xref>
-				we suggest specific locations for you to visit.
+				suggestions are provided as to locations you can visit next.
 			</p>
 			
 		</section>

--- a/content/getting-started/start-here.dita
+++ b/content/getting-started/start-here.dita
@@ -49,7 +49,7 @@
 				</li>
 				
 				<li>
-					Try a Query	
+					Run Your First N1QL Query	
 					
 					<p>
 						<!-- Vertical space -->

--- a/content/getting-started/try-a-query.dita
+++ b/content/getting-started/try-a-query.dita
@@ -24,33 +24,34 @@
 			<p>
 				N1QL embraces the JSON document model and uses SQL-like syntax. In N1QL, you operate on JSON
 				documents, and the result of your operation is another JSON document. N1QL queries can
-				be run on the web from the Couchbase Web Console, or from the command line using the cbq
-				tool.
+				be run from the command line, using the <codeph>cbq</codeph>
+				tool; or by means of the Query Workbench, provided by the Couchbase Web Console.
 			</p>
 			
 			<p>
-				A basic N1QL query has these parts:
+				A basic N1QL query has the following parts:
 			</p>
+			
 			<ul>
 				<li>
-					<codeph>SELECT</codeph>—the fields of each document to return</li>
+					<codeph>SELECT</codeph> &#8212; The fields of each document to return.</li>
 				<li>
-					<codeph>FROM</codeph>—the data bucket to look in</li>
+					<codeph>FROM</codeph> &#8212; The data bucket in which to look.</li>
 				<li>
-					<codeph>WHERE</codeph>—conditions the document must satisfy</li>
+					<codeph>WHERE</codeph> &#8212; The conditions that the document must satisfy.</li>
 			</ul>
 			
 			<p>
 				Here's an example of a basic N1QL query and the JSON document it returns. 
-				The following query asks for the country associated with the airline named
-				<i>Excel Airways</i>:
+				The query asks for the country associated with the airline
+				<i>Excel Airways</i> &#8212; note that for all identifiers (bucket names) that contain a hyphen character, you
+				need to enclose the name with backtick (`) characters:
 			</p>
 			
 			<codeblock outputclass="language-sql">SELECT country FROM `travel-sample` WHERE name = "Excel Airways";</codeblock>
 			
 			<p>
-				Note that for all identifiers (bucket names) that contain a hyphen character, you
-				need to enclose the name with backtick (`) characters. The result appears as follows:
+				The result is as follows:
 			</p>
 			
 			<codeblock outputclass="language-json">{
@@ -72,6 +73,10 @@
     }
 }</codeblock>
 			
+			<p>
+				The country is thus specified as <codeph>United Kingdom</codeph>.
+			</p>
+			
 		</section>
 			
 		<section>
@@ -80,78 +85,99 @@
 				Making N1QL queries
 			</title>
 				<p>
-					After you install Couchbase Server, you can start using N1QL right away. You can make N1QL
-					requests in your applications or run N1QL queries against your database using either
-					the Query Workbench on the Couchbase Web Console or the interactive query shell,
-					<cmdname>cbq</cmdname>.
+					After you install Couchbase Server, you can start using N1QL right away; either with
+					the interactive query shell, <codeph>cbq</codeph>; or with the Query Workbench, 
+					which is provided by the Couchbase Web Console.
 				</p>
 			
-				<p>
-					The <xref href="../tools/query-workbench.dita#topic_prr_nyh_t5">Query Workbench</xref> is
-					integrated with the Couchbase Web console and is available on the
-					<uicontrol>Query</uicontrol> tab. Note that the Query Workbench only runs on nodes
-					which are running the Query service. If the Query service is <i>not </i>running
-					on the current node, it provides a link to the nodes in the cluster which
-					<i>are</i> running the Query service.
-				</p>
+		</section>
+		
+		<section>
+			
+			<title>
+				Try the Interactive Query Shell
+			</title>
 			
 				<p id="run-cbq">
-					The <cmdname>cbq</cmdname> shell is also available. To
-					run the cbq shell, bring up a console window on your machine, type
+					To run the interactive query shell, <codeph>cbq</codeph>, bring up a console window 
+					on your machine, type
 					the following against the prompt, and press the Enter key:
 				</p>
 			
-				<codeblock outputclass="bash">bash -c "clear &amp;&amp; docker exec -it db sh"</codeblock> 
+				<codeblock outputclass="bash">$ bash -c "clear &amp;&amp; docker exec -it db sh"</codeblock> 
 				
 				<p>
 					Then, navigate to the Couchbase <codeph>bin</codeph> directory, and start <codeph>cbq</codeph>:
 				</p>
 			
-				<codeblock outputclass="bash">cd /opt/couchbase/bin
-./cbq</codeblock>	
+				<codeblock outputclass="bash"># cd /opt/couchbase/bin
+# ./cbq</codeblock>	
 			
 				<p>
 					This displays the <codeph>cbq</codeph> shell prompt, against which you can enter N1QL
-					commands.
+					commands against your currently installed buckets. For example, the following query returns
+					the different values used by documents in the <codeph>travel-sample</codeph> bucket 
+					for the <codeph>callsign</codeph>
+					field, limiting the number of results to 5:
 				</p>
+						
+				<codeblock outputclass="language-sql">cbq> SELECT callsign FROM `travel-sample` LIMIT 5;</codeblock>
 			
-			</section>
-			
-			<section>
+				<p>
+					The result is as follows:
+				</p>
 				
-				<title>
-					Trying out N1QL with the <codeph>travel-sample</codeph> bucket
-				</title>
+				<codeblock outputclass="language-sql">{
+    "requestID": "ae6fcd5b-e7f0-4725-ae1d-a38678c13a3e",
+    "signature": {
+        "callsign": "json"
+    },
+    "results": [
+        {
+            "callsign": "MILE-AIR"
+        },
+        {
+            "callsign": "TXW"
+        },
+        {
+            "callsign": "atifly"
+        },
+        {
+             "callsign": null
+        },
+        {
+             "callsign": "LOCAIR"
+        }
+    ],
+    "status": "success",
+    "metrics": {
+        "elapsedTime": "33.748019ms",
+        "executionTime": "33.673901ms",
+        "resultCount": 5,
+        "resultSize": 215
+    }
+}</codeblock>
+						
+				<p>
+					Each
+					document in the bucket contains a <codeph>type</codeph> field that indicates
+					the kind of data the document contains. The <codeph>travel-sample</codeph>
+					bucket contains documents of different kinds, describing different
+					travel-related entities: such as <i>airlines</i> (to which the <codeph>callsign</codeph> field
+					refers), <i>airports</i>, and <i>hotels</i>.
+				</p>
+						
+				<p>
+					The following query returns a maximum of one
+					<codeph>airport</codeph> document, and lists all the fields it
+					contains :
+				</p>
+						
+				<codeblock outputclass="language-sql">cbq> SELECT * FROM `travel-sample` WHERE type="airport" LIMIT 1;</codeblock>
 				
 				<p>
-					Try N1QL and use <cmdname>cbq</cmdname> to run queries against the
-					<codeph>travel-sample</codeph> bucket. The following query returns
-					the different values used for the <codeph>country</codeph>
-					field, limiting the number of results to 10:
+					The query-result is as follows:
 				</p>
-						
-				<codeblock outputclass="language-sql">cbq> SELECT country FROM `travel-sample` LIMIT 5;</codeblock>
-						
-						<p>
-							Each
-							document in the bucket contains a <codeph>type</codeph> field that indicates
-							the kind of data the document contains. The <codeph>travel-sample</codeph>
-							bucket contains two different kinds of documents, describing different
-							travel-related entities: such as <i>airlines</i>, <i>airports</i>, and
-							<i>hotels</i>.
-						</p>
-						
-						<p>
-							The following query returns one
-							<codeph>airport</codeph> document and lists all the fields it
-							contains (note the <codeph>LIMIT</codeph> clause, used to ensure this):
-						</p>
-						
-						<codeblock outputclass="language-sql">cbq> SELECT * FROM `beer-sample` WHERE type="airport" LIMIT 1;</codeblock>
-				
-						<p>
-							The query-result is as follows:
-						</p>
 				
 				<codeblock outputclass="language-sql">{
     "requestID": "c49a5885-9fde-40e3-871f-699f211078cc",
@@ -185,12 +211,11 @@
         "resultSize": 489
     }
 }</codeblock>
-						
-						
-						<p>
-							The following query returns the names of (at a maximum) ten hotels that accept pets,
-							in the city of Medway.
-						</p>
+							
+				<p>
+					The following query returns the names of (at a maximum) ten hotels that accept pets,
+					in the city of Medway.
+				</p>
 								
 				<codeblock outputclass="language-sql">cbq> SELECT name FROM `travel-sample` WHERE type="hotel" AND city="Medway" and pets_ok=true LIMIT 10;
 {
@@ -213,12 +238,12 @@
 }</codeblock>
 						
 						
-						<p>
-							The
-							following query returns the <codeph>name</codeph> and
-							<codeph>phone</codeph> fields from up to 10 documents for hotels in Manchester, where
-							directions are not missing; and orders the results by name:
-						</p>
+				<p>
+					The
+					following query returns the <codeph>name</codeph> and
+					<codeph>phone</codeph> fields from up to 10 documents for hotels in Manchester, where
+					directions are not missing; and orders the results by name:
+				</p>
 				
 				<codeblock outputclass="language-sql">cbq> SELECT name,phone FROM `travel-sample` WHERE type="hotel" AND city="Manchester" and directions IS NOT MISSING ORDER BY name LIMIT 10;
 {
@@ -251,6 +276,101 @@
 }</codeblock>
 				
 			</section>
+		
+		<section>
+			
+			<title>
+				Try the Query Workbench
+			</title>
+		
+			<p>
+				The Couchbase Web Console
+				provides a <i>Query Workbench</i>, at which you can compose and execute N1QL queries.
+				Left-click on the <uicontrol>Query</uicontrol> tab, located on the horizontal control-bar, near
+				the top of the Couchbase Web Console:
+			</p>
+			
+			<p>
+				<image href="./images/queryButton.png" id="query_button" align="left" width="100"/>
+			</p>
+			
+			<p>
+				This brings up the Query Workbench. 
+			</p>
+			
+			<p>
+				<image href="./images/queryWorkbench.png" id="query_workbench" align="left" width="720"/>
+			</p>
+			
+			<p>
+				The workbench has three principal areas, which are:
+			</p>
+			
+			<ul>
+				<li>
+					An upper panel, which features the prompt <codeph>Enter a query here</codeph>: and this is indeed
+					where you will type your N1QL query. 
+					
+					<p>
+						<!-- Vertical space -->
+					</p>
+					
+				</li>
+				
+				<li>
+					A <uicontrol>Bucket Analysis</uicontrol> panel, at the lower-left. This provides information on the
+					buckets currently maintained by your system. Right now, it shows that just one exists; the
+					bucket <codeph>travel-sample</codeph>. 
+					
+					<p>
+						<!-- Vertical space -->
+					</p>
+					
+				</li>
+				
+				<li>
+					A <uicontrol>Results</uicontrol> panel, at the lower-right. This shows query-results; and provides
+					a number of options for their display. To start with, you will use the default option, which is
+					selectable by the <uicontrol>JSON</uicontrol> button, and duly displays results in JSON-format.
+					
+					<p>
+						<!-- Vertical space -->
+					</p>
+					
+				</li>
+			</ul>
+			
+			<p>
+				You can now use the Query Workbench to enter a N1QL query. In the upper panel, enter the following:
+			</p>
+			
+			<p>
+				<image href="./images/firstQuery.png" id="first_query" align="left" width="660"/>
+			</p>
+			
+			<p>
+				To execute your query, left-click on the <uicontrol>Execute</uicontrol> button, at the upper-left:
+			</p>
+			
+			<p>
+				<image href="./images/executeButton.png" id="execute_button" align="left" width="100"/>
+			</p>
+			
+			<p>
+				Query-results now appear in the <uicontrol>Results</uicontrol> panel:
+			</p>
+			
+			<p>
+				<image href="./images/queryResultsJSON.png" id="query_results_json" align="left" width="660"/>
+			</p>
+			
+			<p>
+				As you can see, a single document was found to match your specified criterion: which was the document
+				whose <codeph>name</codeph> value is <codeph>40-Mile Air</codeph> (which is, in fact, the document you took an initial
+				look at, during the previous stage of the <i>Getting Started</i> sequence).
+			</p>
+			
+		</section>
 
 					
 		<section>	

--- a/content/getting-started/try-a-query.dita
+++ b/content/getting-started/try-a-query.dita
@@ -6,13 +6,11 @@
 <topic xml:lang="en-us" id="tryAQuery">
 	
 	<title>
-		Try a Query
+		Run Your First N1QL Query
 	</title>
 	
 	<shortdesc>
-		Couchbase Server allows you to search for data interactively: the Couchbase Web Console
-		provides a <i>Query Workbench</i>, at which you can compose and execute queries, and see
-		the returned results.
+		N1QL (pronounced "nickel") is the Couchbase Server query language.
 	</shortdesc>
 	
 	<body> 
@@ -20,230 +18,241 @@
 		<section>
 			
 			<title>
-				Access the Query Workbench
+				About N1QL
 			</title>
 			
 			<p>
-				Left-click on the <uicontrol>Query</uicontrol> tab, located on the horizontal control-bar, near
-				the top of the Couchbase Web Console:
+				N1QL embraces the JSON document model and uses SQL-like syntax. In N1QL, you operate on JSON
+				documents, and the result of your operation is another JSON document. N1QL queries can
+				be run on the web from the Couchbase Web Console, or from the command line using the cbq
+				tool.
 			</p>
 			
 			<p>
-				<image href="./images/queryButton.png" id="query_button" align="left" width="100"/>
+				A basic N1QL query has these parts:
 			</p>
+			<ul>
+				<li>
+					<codeph>SELECT</codeph>—the fields of each document to return</li>
+				<li>
+					<codeph>FROM</codeph>—the data bucket to look in</li>
+				<li>
+					<codeph>WHERE</codeph>—conditions the document must satisfy</li>
+			</ul>
 			
 			<p>
-				This brings up the Query Workbench. 
+				Here's an example of a basic N1QL query and the JSON document it returns. 
+				The following query asks for the country associated with the airline named
+				<i>Excel Airways</i>:
 			</p>
+			
+			<codeblock outputclass="language-sql">SELECT country FROM `travel-sample` WHERE name = "Excel Airways";</codeblock>
+			
+			<p>
+				Note that for all identifiers (bucket names) that contain a hyphen character, you
+				need to enclose the name with backtick (`) characters. The result appears as follows:
+			</p>
+			
+			<codeblock outputclass="language-json">{
+    "requestID": "9e1cd084-f45e-4059-9e7a-edec30f60dd2",
+    "signature": {
+        "country": "json"
+	},
+    "results": [
+        {
+            "country": "United Kingdom"
+        }
+    ],
+    "status": "success",
+	"metrics": {
+        "elapsedTime": "7.42097249s",
+        "executionTime": "7.420925841s",
+        "resultCount": 1,
+        "resultSize": 51
+    }
+}</codeblock>
 			
 		</section>
-		
-		<section>
 			
+		<section>
+				
 			<title>
-				Examine the Query Workbench
+				Making N1QL queries
 			</title>
+				<p>
+					After you install Couchbase Server, you can start using N1QL right away. You can make N1QL
+					requests in your applications or run N1QL queries against your database using either
+					the Query Workbench on the Couchbase Web Console or the interactive query shell,
+					<cmdname>cbq</cmdname>.
+				</p>
+			
+				<p>
+					The <xref href="../tools/query-workbench.dita#topic_prr_nyh_t5">Query Workbench</xref> is
+					integrated with the Couchbase Web console and is available on the
+					<uicontrol>Query</uicontrol> tab. Note that the Query Workbench only runs on nodes
+					which are running the Query service. If the Query service is <i>not </i>running
+					on the current node, it provides a link to the nodes in the cluster which
+					<i>are</i> running the Query service.
+				</p>
+			
+				<p id="run-cbq">
+					The <cmdname>cbq</cmdname> shell is also available. To
+					run the cbq shell, bring up a console window on your machine, type
+					the following against the prompt, and press the Enter key:
+				</p>
+			
+				<codeblock outputclass="bash">bash -c "clear &amp;&amp; docker exec -it db sh"</codeblock> 
+				
+				<p>
+					Then, navigate to the Couchbase <codeph>bin</codeph> directory, and start <codeph>cbq</codeph>:
+				</p>
+			
+				<codeblock outputclass="bash">cd /opt/couchbase/bin
+./cbq</codeblock>	
+			
+				<p>
+					This displays the <codeph>cbq</codeph> shell prompt, against which you can enter N1QL
+					commands.
+				</p>
+			
+			</section>
+			
+			<section>
+				
+				<title>
+					Trying out N1QL with the <codeph>travel-sample</codeph> bucket
+				</title>
+				
+				<p>
+					Try N1QL and use <cmdname>cbq</cmdname> to run queries against the
+					<codeph>travel-sample</codeph> bucket. The following query returns
+					the different values used for the <codeph>country</codeph>
+					field, limiting the number of results to 10:
+				</p>
+						
+				<codeblock outputclass="language-sql">cbq> SELECT country FROM `travel-sample` LIMIT 5;</codeblock>
+						
+						<p>
+							Each
+							document in the bucket contains a <codeph>type</codeph> field that indicates
+							the kind of data the document contains. The <codeph>travel-sample</codeph>
+							bucket contains two different kinds of documents, describing different
+							travel-related entities: such as <i>airlines</i>, <i>airports</i>, and
+							<i>hotels</i>.
+						</p>
+						
+						<p>
+							The following query returns one
+							<codeph>airport</codeph> document and lists all the fields it
+							contains (note the <codeph>LIMIT</codeph> clause, used to ensure this):
+						</p>
+						
+						<codeblock outputclass="language-sql">cbq> SELECT * FROM `beer-sample` WHERE type="airport" LIMIT 1;</codeblock>
+				
+						<p>
+							The query-result is as follows:
+						</p>
+				
+				<codeblock outputclass="language-sql">{
+    "requestID": "c49a5885-9fde-40e3-871f-699f211078cc",
+    "signature": {
+        "*": "*"
+    },
+    "results": [
+        {
+            "travel-sample": {
+                "airportname": "Calais Dunkerque",
+                "city": "Calais",
+                "country": "France",
+                "faa": "CQF",
+                "geo": {
+                    "alt": 12,
+                    "lat": 50.962097,
+                    "lon": 1.954764
+                },
+                "icao": "LFAC",
+                "id": 1254,
+                "type": "airport",
+                "tz": "Europe/Paris"
+            }
+        }
+    ],
+    "status": "success",
+    "metrics": {
+        "elapsedTime": "16.272029ms",
+        "executionTime": "16.216091ms",
+        "resultCount": 1,
+        "resultSize": 489
+    }
+}</codeblock>
+						
+						
+						<p>
+							The following query returns the names of (at a maximum) ten hotels that accept pets,
+							in the city of Medway.
+						</p>
+								
+				<codeblock outputclass="language-sql">cbq> SELECT name FROM `travel-sample` WHERE type="hotel" AND city="Medway" and pets_ok=true LIMIT 10;
+{
+    "requestID": "b6dc75dd-4ed2-40de-83c8-9aebb3820ad8",
+    "signature": {
+        "name": "json"
+    },
+    "results": [
+        {
+            "name": "Medway Youth Hostel"
+        }
+    ],
+    "status": "success",
+    "metrics": {
+        "elapsedTime": "45.380072ms",
+        "executionTime": "45.326531ms",
+        "resultCount": 1,
+        "resultSize": 53
+    }
+}</codeblock>
+						
+						
+						<p>
+							The
+							following query returns the <codeph>name</codeph> and
+							<codeph>phone</codeph> fields from up to 10 documents for hotels in Manchester, where
+							directions are not missing; and orders the results by name:
+						</p>
+				
+				<codeblock outputclass="language-sql">cbq> SELECT name,phone FROM `travel-sample` WHERE type="hotel" AND city="Manchester" and directions IS NOT MISSING ORDER BY name LIMIT 10;
+{
+    "requestID": "a3561cba-2377-4282-9c0f-68fc627950f6",
+    "signature": {
+        "name": "json",
+        "phone": "json"
+    },
+    "results": [
+        {
+            "name": "The Mitre Hotel",
+            "phone": "+44 161 834-4128"
+        },
+        {
+            "name": "Sachas Hotel",
+            "phone": null
+        },
+        {
+            "name": "Hilton Chambers",
+            "phone": "+44 161 236-4414"
+        }
+    ],
+    "status": "success",
+    "metrics": {
+        "elapsedTime": "22.211069ms",
+        "executionTime": "22.108582ms",
+        "resultCount": 3,
+        "resultSize": 253
+    }
+}</codeblock>
+				
+			</section>
 
-			<p>
-				<image href="./images/queryWorkbench.png" id="query_workbench" align="left" width="720"/>
-			</p>
-			
-			<p>
-				The workbench has three principal areas, which are:
-			</p>
-			
-			<ul>
-				<li>
-					An upper panel, which features the prompt <codeph>Enter a query here</codeph>: and this is indeed
-					where you will type your query. 
 					
-					<p>
-						<!-- Vertical space -->
-					</p>
-					
-				</li>
-				
-				<li>
-					A <uicontrol>Bucket Analysis</uicontrol> panel, at the lower-left. This provides information on the
-					buckets currently maintained by your system. Right now, it shows that just one exists; the
-					bucket <codeph>travel-sample</codeph>. 
-					
-					<p>
-						<!-- Vertical space -->
-					</p>
-					
-				</li>
-				
-				<li>
-					A <uicontrol>Results</uicontrol> panel, at the lower-right. This shows query-results; and provides
-					a number of options for their display. To start with, you will use the default option, which is
-					selectable by the <uicontrol>JSON</uicontrol> button, and duly displays results in JSON-format.
-					
-					<p>
-						<!-- Vertical space -->
-					</p>
-					
-				</li>
-			</ul>
-			
-			<p>
-				You will now use the Query Workbench to enter your first query.
-			</p>
-			
-		</section>
-		
-		<section>
-			
-			<title>
-				Enter a Query
-			</title>
-			
-			<p>
-				In the upper panel, enter the following text:
-			</p>
-			
-			<p>
-				<image href="./images/firstQuery.png" id="first_query" align="left" width="660"/>
-			</p>
-			
-			<p>
-				Note the mandatory use of <i>reverse quotes</i> around the bucket-name, <codeph>travel-sample</codeph>. Note
-				also that you must terminate your query with a semi-colon.
-			</p>
-			
-			<p>
-				This query uses the Couchbase <b>N1QL</b> declarative query-language, which is specially defined for
-				the querying of JSON documents. A basic N1QL query has three parts:
-			</p>
-			
-			<ul>
-				<li>
-					<codeph>SELECT</codeph> &#8212; specifying the field or fields to be returned from each document
-					
-					<p>
-						<!-- Vertical space -->
-					</p>
-					
-				</li>
-				
-				<li>
-					<codeph>FROM</codeph> &#8212; the data-bucket that is to be searched
-					
-					<p>
-						<!-- Vertical space -->
-					</p>
-					
-				</li>
-				
-				<li>
-					<codeph>WHERE</codeph> &#8212; the conditions that the document must satisfy, for data to be returned
-					
-					<p>
-						<!-- Vertical space -->
-					</p>
-					
-				</li>
-				
-			</ul>
-			
-			<p>
-				In your first query, then, you have specified that the <codeph>name</codeph> field of each document from
-				the <codeph>travel-sample</codeph> bucket should be returned; provided that the value of the document's
-				<codeph>call-sign</codeph> field is <codeph>MILE-AIR</codeph>.
-			</p>
-			
-			<p>
-				To execute your query, left-click on the <uicontrol>Execute</uicontrol> button, at the upper-left:
-			</p>
-			
-			<p>
-				<image href="./images/executeButton.png" id="execute_button" align="left" width="100"/>
-			</p>
-			
-			<p>
-				Query-results now appear in the <uicontrol>Results</uicontrol> panel:
-			</p>
-			
-			<p>
-				<image href="./images/queryResultsJSON.png" id="query_results_json" align="left" width="660"/>
-			</p>
-			
-			<p>
-				As you can see, a single document was found to match your specified criterion: which was the document
-				whose <codeph>name</codeph> value is <codeph>40-Mile Air</codeph> (which is indeed the document you took an initial
-				look at, during the previous stage of the <i>Getting Started</i> sequence).
-			</p>
-			
-		</section>
-		
-		<section>
-			
-			<title>
-				Try Different Query-Options
-			</title>
-			
-			<p>
-				The Query Workbench allows you to display query-results in different ways. This can be better
-				shown with a less restrictive query. Therefore, modify your previous query
-				by removing the <codeph>WHERE</codeph> clause, as follows:
-			</p>
-			
-			<p>
-				<image href="./images/queryNoWHERE.png" id="query_no_where" align="left" width="642"/>
-			</p>
-			
-			<p>
-				This modified query asks for the <codeph>name</codeph> value of every document in the <codeph>travel-sample</codeph>
-				bucket, without exception. Again, left-click on the <uicontrol>Execute</uicontrol> button. The 
-				<uicontrol>Results</uicontrol> panel now appears as follows:
-			</p>
-			
-			<p>
-				<image href="./images/queryResultsJSONnoWHERE.png" id="query_results_json_no_where" align="left" width="660"/>
-			</p>
-			
-			<p>
-				The <uicontrol>Results Summary</uicontrol> horizontal bar, near the top of the UI, indicates that your query was
-				indeed successful, and that 31,591 individual results were returned. Each returned result is a JSON document,
-				within an array. Vertical scrolling is provided. Additionally, the UI provides different options for viewing 
-				results, which are especially useful when
-				result-sets are very large. These options can be selected by means of buttons, at the upper-left:
-			</p>
-			
-			<p>
-				<image href="./images/queryDisplayButtons.png" id="query_display_buttons" align="left" width="180"/>
-			</p>
-			
-			<p>
-				Left-click on the <uicontrol>Table</uicontrol> button. The <uicontrol>Results</uicontrol> panel now appears
-				as follows:
-			</p>
-			
-			<p>
-				<image href="./images/queryResultsTable.png" id="query_results_table" align="left" width="660"/>
-			</p>
-			
-			<p>
-				And now, left-click on <uicontrol>Tree</uicontrol>:
-			</p>
-			
-			<p>
-				<image href="./images/queryResultsTree.png" id="query_results_tree" align="left" width="660"/>
-			</p>
-			
-			<p>
-				You can continue to experiment with these options whenever you need a clearer view of the 
-				result-set you have returned.
-			</p>
-			
-			<p>
-				Note that options for saving queries and results are also provided, by means of the <uicontrol>Save Query</uicontrol>
-				and <uicontrol>Save JSON,</uicontrol> buttons. In each case, you are prompted for a filename, and the query or
-				results-set is duly saved.
-			</p>
-				
-		</section>
-		
 		<section>	
 			
 			<title>
@@ -265,18 +274,53 @@
 			</title>
 			
 			<p>
-				In this section, we've performed two very simple N1QL queries. In fact, the language provides
-				the opportunity for queries that are far more complex, by means of extensive syntactic options. If you
-				wish to investigate these right away, before running your first program, you can go to
-				<xref href="../sdk/n1ql-query.dita" scope="local" format="dita">Querying with N1QL</xref>.
+				In addition to following this brief tutorial, you can learn more about N1QL by looking
+				at these in-depth resources:
 			</p>
 			
-			<p>
-				As well as interactively specifying N1QL queries from the Query Workbench, you can also do so
-				by means of <codeph>cbq</codeph>: this is an interactive shell-program, available in your
-				Couchbase applications directory. For detailed information, see
-				<xref href="../tools/cbq-shell.dita" scope="local" format="dita">cbq: The Command Line Shell for N1QL</xref>. 
-			</p>
+			<ul>
+				<li>
+					The <xref href="http://query.pub.couchbase.com/tutorial/#1" format="html"
+						scope="external">online interactive tutorial</xref> allows you to learn about N1QL
+					without having Couchbase Server installed in your own environment. It's a
+					self-contained tutorial that runs in a web browser and lets you modify the sample
+					queries. The tutorial covers SELECT statements in detail, including examples of JOIN,
+					NEST, GROUP BY, and other typical clauses. 
+				</li>
+				
+				<li>
+					The <xref href="http://docs.couchbase.com/files/Couchbase-N1QL-CheatSheet.pdf"
+						format="pdf" scope="external">N1QL cheat sheet</xref> provides a concise summary
+					of the basic syntax elements. Print it out and keep it on your desk where it'll be
+					handy for quick reference.
+				</li>
+				
+				<li>
+					The <xref href="../n1ql/n1ql-language-reference/index.dita#n1ql-lang-ref"/> contains
+					details about N1QL syntax and usage.
+				</li>
+				
+				<li>
+					Live and recorded <xref href="http://www.couchbase.com/nosql-resources/webinar"
+						format="html" scope="external">Webinars</xref> presented by Couchbase engineers
+					and product managers highlight features and use cases of Couchbase Server, including
+					N1QL. Here are some links to webinars devoted entirely to N1QL: <xref
+						href="https://event.on24.com/eventRegistration/EventLobbyServlet?target=reg20.jsp&amp;eventid=962567&amp;sessionid=1&amp;key=00929333AAF46D0054877324FBC3CB85&amp;sourcepage=register"
+						format="html" scope="external">Couchbase 103: Querying</xref> and <xref
+							href="http://info.couchbase.com/webinar-N1QL-ad-hoc-querying-for-NoSQL-applications.html"
+							format="html" scope="external">Ad hoc Querying for NoSQL</xref>.
+				</li>
+				
+				<li>
+					<xref href="http://blog.couchbase.com" format="html" scope="external">Couchbase
+						blogs</xref> include articles written by Couchbase SDK developers.
+				</li>
+				
+				<li>The <xref href="https://forums.couchbase.com/c/n1ql" format="html" scope="external"
+					>Couchbase forum</xref> is a community resource where you can ask questions, find
+					answers, and discuss N1QL with other developers and the Couchbase team.
+				</li>
+			</ul>
 
 		</section>
 		

--- a/content/getting-started/try-a-query.dita
+++ b/content/getting-started/try-a-query.dita
@@ -100,8 +100,8 @@
 			
 				<p id="run-cbq">
 					To run the interactive query shell, <codeph>cbq</codeph>, bring up a console window 
-					on your machine, type
-					the following against the prompt, and press the Enter key:
+					on your machine, and enter
+					the following against the prompt:
 				</p>
 			
 				<codeblock outputclass="bash">$ bash -c "clear &amp;&amp; docker exec -it db sh"</codeblock> 
@@ -157,20 +157,14 @@
         "resultSize": 215
     }
 }</codeblock>
-						
-				<p>
-					Each
-					document in the bucket contains a <codeph>type</codeph> field that indicates
-					the kind of data the document contains. The <codeph>travel-sample</codeph>
-					bucket contains documents of different kinds, describing different
-					travel-related entities: such as <i>airlines</i> (to which the <codeph>callsign</codeph> field
-					refers), <i>airports</i>, and <i>hotels</i>.
-				</p>
-						
-				<p>
-					The following query returns a maximum of one
-					<codeph>airport</codeph> document, and lists all the fields it
-					contains :
+			
+			<p>
+				The result thus contains five callsign-values. A callsign is associated with an airline; and
+				<codeph>airline</codeph> is one of the document-types that the <codeph>travel-sample</codeph> bucket
+				contains. Others are <codeph>airport</codeph> and <codeph>hotel</codeph>. You can search on a type: for example,
+				the following query returns a maximum of one
+				<codeph>airport</codeph> document, and lists all the fields it
+				contains :
 				</p>
 						
 				<codeblock outputclass="language-sql">cbq> SELECT * FROM `travel-sample` WHERE type="airport" LIMIT 1;</codeblock>
@@ -236,12 +230,11 @@
         "resultSize": 53
     }
 }</codeblock>
-						
-						
+								
 				<p>
 					The
 					following query returns the <codeph>name</codeph> and
-					<codeph>phone</codeph> fields from up to 10 documents for hotels in Manchester, where
+					<codeph>phone</codeph> fields for up to 10 documents for hotels in Manchester, where
 					directions are not missing; and orders the results by name:
 				</p>
 				


### PR DESCRIPTION
Incorporated the command-line examples and descriptions from the former "running your first N1QL Query" page into the try-a-query page, which itself is re-titled "Run Your First N1QL Query". Changed examples for docker and travel-sample-based environment. Updated links within documents across Getting Started.