### PR TITLE
Update release notes for Kafka Connector 3.1.2

### DIFF
--- a/content/connectors/kafka-3.1/release-notes.dita
+++ b/content/connectors/kafka-3.1/release-notes.dita
@@ -5,6 +5,18 @@
     <shortdesc>Release notes for the 3.1 version of the Kafka Connector. </shortdesc>
     <conbody>
         <section>
+            <title>Couchbase Kafka Connector 3.1.2 GA (14 March 2017)</title>
+            <p>Version 3.1.2 is maintenance release..</p>
+            <ul>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-66" format="html" scope="external">KAFKAC-66</xref>:
+                    On backfilling from large bucket, it is possible to get OOM when internal queue is not drained quickly
+                    enough to relay the data into Kafka.
+                </li>
+            </ul>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.1.2/kafka-connect-couchbase-3.1.2.zip" format="html" scope="external">kafka-connect-couchbase-3.1.2.zip</xref></p>
+        </section>
+        <section>
             <title>Couchbase Kafka Connector 3.1.1 GA (21 February 2017)</title>
             <p>Version 3.1.1 is maintenance release. It contains fixes for resuming DCP streams after restart.</p>
             <ul>
@@ -14,7 +26,7 @@
                     number zero (0) and starting from the beginning (duplicating events in Kafka topic).
                 </li>
             </ul>
-            <p><xref href="http://packages.couchbase.com/clients/kafka/3.1.0/kafka-connect-couchbase-3.1.0.zip" format="html" scope="external">kafka-connect-couchbase-3.1.0.zip</xref></p>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.1.1/kafka-connect-couchbase-3.1.1.zip" format="html" scope="external">kafka-connect-couchbase-3.1.1.zip</xref></p>
         </section>
         <section>
             <title>Couchbase Kafka Connector 3.1.0 GA (03 January 2017)</title>
@@ -26,6 +38,79 @@
                 </li>
             </ul>
             <p><xref href="http://packages.couchbase.com/clients/kafka/3.1.0/kafka-connect-couchbase-3.1.0.zip" format="html" scope="external">kafka-connect-couchbase-3.1.0.zip</xref></p>
+        </section>
+
+        <section>
+            <title>Couchbase Kafka Connector 3.0.0 GA (14 December 2016)</title>
+            <p>Version 3.0.0 is GA release. It brings documentation update.</p>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.0.0/kafka-connect-couchbase-3.0.0.zip" format="html" scope="external">kafka-connect-couchbase-3.0.0.zip</xref></p>
+        </section>
+        <section>
+            <title>Couchbase Kafka Connector 3.0.0 BETA (22 November 2016)</title>
+            <p>Version 3.0.0-BETA is pre-release version of the 3.0.0. It brings documentation
+                update, feature enhancements and bug fixes</p>
+            <ul>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-52" format="html" scope="external">KAFKAC-52</xref>:
+                    Support for SSL connections
+                </li>
+                <li>
+                    Update dependencies: dcp-client to 0.7.0, and confluent libraries up to versions shipped with 3.1.1
+                </li>
+                <li>
+                    Cleanup various configuration workarounds for platform 3.0
+                </li>
+            </ul>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.0.0-BETA/kafka-connect-couchbase-3.0.0-BETA.zip" format="html" scope="external">kafka-connect-couchbase-3.0.0-BETA.zip</xref></p>
+        </section>
+        <section>
+            <title>Couchbase Kafka Connector 3.0.0 DP4 (5 November 2016)</title>
+            <p>Version 3.0.0-DP4 is the fourth developer preview of the 3.0.x series. </p>
+            <ul>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-54" format="html" scope="external">KAFKAC-54</xref>:
+                    Create example of using in Kafka Stream to process events from Couchbase
+                </li>
+                <li>
+                    Rename internal classes, and make configuration more consistent with other connectors (e.g. instead
+                    of timeout_ms, use timeout.ms)
+                </li>
+                <li>
+                    Allow to override internal convertor into SourceRecord, and allow to inject Filter class to skip
+                    events before writing into Kafka
+                </li>
+            </ul>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.0.0-DP4/kafka-connect-couchbase-3.0.0-DP4.zip" format="html" scope="external">kafka-connect-couchbase-3.0.0-DP4.zip</xref></p>
+        </section>
+        <section>
+            <title>Couchbase Kafka Connector 3.0.0 DP3 (20 October 2016)</title>
+            <p>Version 3.0.0-DP3 is the third developer preview of the 3.0.x series. It implements new features and also includes bug fixes to previous release.</p>
+            <ul>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-50" format="html" scope="external">KAFKAC-50</xref>:
+                    Allow to buffer DCP snapshots for consistent writes.
+                </li>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-51" format="html" scope="external">KAFKAC-51</xref>:
+                    Specify key for SourceRecord. Allows to use multiple Kafka partitions.
+                </li>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-53" format="html" scope="external">KAFKAC-53</xref>:
+                    Node-aware distribution of partitions for Tasks. Reduces amount of resources allocated on the server.
+                </li>
+            </ul>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.0.0-DP3/kafka-connect-couchbase-3.0.0-DP3.zip" format="html" scope="external">kafka-connect-couchbase-3.0.0-DP3.zip</xref></p>
+        </section>
+        <section>
+            <title>Couchbase Kafka Connector 3.0.0 DP2 (24 September 2016)</title>
+            <p>Version 3.0.0-DP2 is the second developer preview of the 3.0.x series. It improves configuration. And now
+            can maintain replication state, which allow to resume transmission.</p>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.0.0-DP2/kafka-connect-couchbase-3.0.0-DP2.zip" format="html" scope="external">kafka-connect-couchbase-3.0.0-DP2.zip</xref></p>
+        </section>
+        <section>
+            <title>Couchbase Kafka Connector 3.0.0 DP1 (6 September 2016)</title>
+            <p>Version 3.0.0-DP1 is the first developer preview of the 3.0.x series.</p>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.0.0-DP1/kafka-connect-couchbase-3.0.0-DP1.zip" format="html" scope="external">kafka-connect-couchbase-3.0.0-DP1.zip</xref></p>
         </section>
     </conbody>
 </concept>


### PR DESCRIPTION
Also according to KAFKAC-63 duplicate 3.0.x release notes here

/cc @mattcarabine 