### PR TITLE
Update dotnet releases for 2.4.2

### DIFF
--- a/content/sdk/dotnet/releases.dita
+++ b/content/sdk/dotnet/releases.dita
@@ -10,21 +10,28 @@
     <section>
       <title>Current Release</title>
       <ul>
-        <li>2.3.11 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.11.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.11/" format="html" scope="external">API Reference</xref></li>
+        <li>2.4.2 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.4/Couchbase-Net-Client-2.4.2.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.4.2/" format="html" scope="external">API Reference</xref></li>
       </ul>
     </section>
+		<section>
+			<title>Previous Releases 2.4</title>
+			<ul>
+				<li>2.4.0 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.4/Couchbase-Net-Client-2.4.0.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.4.0/" format="html" scope="external">API Reference</xref></li>
+			</ul>
+		</section>
     <section>
       <title>Previous Releases - 2.3</title>
       <ul>
-				<li>2.3.10 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.10.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.10/" format="html" scope="external">API Reference</xref></li>
-        <li>2.3.9 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.9.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.9/" format="html" scope="external">API Reference</xref></li>
-	    <li>2.3.8 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.8.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.8/" format="html" scope="external">API Reference</xref></li>
-        <li>2.3.6 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.6.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.6/" format="html" scope="external">API Reference</xref></li>
-        <li>2.3.5 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.5.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.5/" format="html" scope="external">API Reference</xref></li>
-        <li>2.3.4 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.4.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.4/" format="html" scope="external">API Reference</xref></li>
-        <li>2.3.3 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.3.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.3/" format="html" scope="external">API Reference</xref></li>
-        <li>2.3.1 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.1.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.1/" format="html" scope="external">API Reference</xref></li>
-        <li>2.3.0 GA - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.0.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.0/" format="html" scope="external">API Reference</xref></li>
+				<li>2.3.11 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.11.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.11/" format="html" scope="external">API Reference</xref></li>
+				<li>2.3.10 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.10.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.10/" format="html" scope="external">API Reference</xref></li>
+        <li>2.3.9 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.9.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.9/" format="html" scope="external">API Reference</xref></li>
+	    	<li>2.3.8 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.8.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.8/" format="html" scope="external">API Reference</xref></li>
+        <li>2.3.6 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.6.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.6/" format="html" scope="external">API Reference</xref></li>
+        <li>2.3.5 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.5.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.5/" format="html" scope="external">API Reference</xref></li>
+        <li>2.3.4 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.4.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.4/" format="html" scope="external">API Reference</xref></li>
+        <li>2.3.3 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.3.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.3/" format="html" scope="external">API Reference</xref></li>
+        <li>2.3.1 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.1.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.1/" format="html" scope="external">API Reference</xref></li>
+        <li>2.3.0 - <xref href="https://s3.amazonaws.com/packages.couchbase.com/clients/net/2.3/Couchbase-Net-Client-2.3.0.zip" format="html" scope="external">Download</xref> | <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.3.0/" format="html" scope="external">API Reference</xref></li>
       </ul>
     </section>
   </body>


### PR DESCRIPTION
Adds links for 2.4.0 and 2.4.2, plus some formatting updates.

Also probably worth back-porting to previous versions as it's just reference for client versions.