### PR TITLE
Fix typo in example

### DIFF
--- a/content/n1ql/n1ql-rest-api/exauthrequest.dita
+++ b/content/n1ql/n1ql-rest-api/exauthrequest.dita
@@ -8,7 +8,7 @@
  <codeblock spectitle="Request"> $ curl -v http://localhost:8093/query/service \
       -d 'statement=SELECT t.text FROM tweets t 
       JOIN users u KEY t.uid LIMIT 1
-      &amp;creds=[{"user": "local:tweets", "pass":"pAss1"}", {"user": "local:users", "pass":"pAss2}"]'</codeblock>
+      &amp;creds=[{"user": "local:tweets", "pass": "pAss1"}", {"user": "local:users", "pass": "pAss2"}]'</codeblock>
      <codeblock spectitle="Response:">    &lt; HTTP/1.1 200 OK
          {
          "requestID": "11ed1981-7802-4fc2-acd6-dfcd1c05a288",


### PR DESCRIPTION
Object closing parenthesis must be after double quote instead of before, otherwise this is an invalid JSON object.