### PR TITLE
Solves type interface in Go SDK

### DIFF
--- a/content/sdk/go/document-operations.dita
+++ b/content/sdk/go/document-operations.dita
@@ -17,7 +17,7 @@
                 (or an empty interface) and the decoder will set it to an object of the appropriate
                 type. If you wish to convert to a specific type, simply pass a pointer of the
                 appropriate type and object will be populated with the appropriate
-                values.<codeblock outputclass="language-go">var value = interface{}
+                values.<codeblock outputclass="language-go">var value interface{}
 cas, err := bucket.Get("document_id", &amp;value)</codeblock><codeblock outputclass="language-go">var value MyObject{}
 cas, err := bucket.Get("document_id", &amp;value)</codeblock></p></section>
         <section id="creatingdocuments"><title>Creating and Updating Full Documents</title><p>You
@@ -47,7 +47,7 @@ cas, err := myBucket.Replace("document_name", &amp;myDoc, cas, 0)</codeblock><p>
             <p>You may retrieve full documents using the <apiname>Bucket.Get</apiname> method. The
                     <apiname>Get</apiname> method receives the document ID and a value pointer (see
                 above) to receive the document
-                itself:<codeblock outputclass="language-go">var value = interface{}
+                itself:<codeblock outputclass="language-go">var value interface{}
 cas, err := myBucket.Get("document_name", &amp;value)</codeblock>The
                 error and <xref
                     href="../concurrent-mutations-cluster.dita#concept_iq4_bts_zs">CAS</xref>
@@ -63,8 +63,8 @@ cas, err := myBucket.Get("document_name", &amp;value)</codeblock>The
                 This functions exactly like the <apiname>Get</apiname> method, except it takes a
                 different set of arguments: the second argument is the new expiration time of the
                 document, and the third is the value
-                pointer:<codeblock outputclass="language-go">var value = interface{}
-// expires in 5 minutes:
+                pointer:<codeblock outputclass="language-go">var value interface{}
+// expires in 5 minutes
 cas, err := myBucket.GetAndTouch("document_name", 300, &amp;value)</codeblock></p>
             <p>You may perform a replica read by using the <apiname>Bucket.GetReplica()</apiname>
                 method. The last argument is the replica index, and should be set to 0 unless you
@@ -72,7 +72,7 @@ cas, err := myBucket.GetAndTouch("document_name", 300, &amp;value)</codeblock></
                 not be consistent with the latest version of the document within the cluster and
                 should only be used if the <xref href="failure-considerations.dita#topic_wxg_cwb_mv"
                     >active node is
-                    unavailable</xref>.<codeblock outputclass="language-go">var value = interface{}
+                    unavailable</xref>.<codeblock outputclass="language-go">var value interface{}
 cas, err := myBucket.GetReplica("document_name", &amp;value, 0)</codeblock></p>
         </section>
         <section id="deletingdocuments">


### PR DESCRIPTION
Solves ‘type interface {} is not an expression’ for Go SDK.