### PR TITLE
Mention libev in plugins

### DIFF
--- a/content/sdk/c/start-using-sdk.dita
+++ b/content/sdk/c/start-using-sdk.dita
@@ -18,7 +18,7 @@
                     <li>N1QL query operations (<apiname>lcb_n1ql_query</apiname>)</li>
                     <li>Map Reduce (view) query operations (<apiname>lcb_view_query</apiname>)</li>
                     <li>Secure SSL connections (Couchbase Enterprise only)</li>
-                    <li>Pluggable non-blocking event loops such as <b>libevent</b> and <b>libuv</b>-
+                <li>Pluggable non-blocking event loops such as <b>libevent</b>, <b>libev</b>, and <b>libuv</b>-
                         integrate with your own non-blocking application, or use
                             <apiname>lcb_wait</apiname> in blocking code</li>
                 </ul>Note that SSL and N1QL features depend on server support. See <xref


### PR DESCRIPTION
Apparently this confused a user into thinking that libev is no longer supported or is deprecated.