### PR TITLE
Add note to redirect user to new version of spark docs

### DIFF
--- a/content/connectors/spark-1.0/spark-shell.dita
+++ b/content/connectors/spark-1.0/spark-shell.dita
@@ -13,7 +13,7 @@
 			<p>The Spark shell provides an easy and convenient way to prototype certain operations quickly,
 				without having to develop a full program, packaging it and then deploying it.</p>
 			
-			<note>Upgrade now to <xref href="https://developer.couchbase.com/documentation/server/current/connectors/spark-2.0/spark-intro.html" format="html" scope="external" >Couchbase Spark Connector 2.0</xref>.</note>
+			<note>Upgrade now to <xref href="https://developer.couchbase.com/documentation/server/current/connectors/spark-2.0/spark-shell.html" format="html" scope="external" >Couchbase Spark Connector 2.0</xref>.</note>
 
 			<p>You need to <xref href="https://spark.apache.org/downloads.html" format="html" scope="external">download</xref> Apache Spark from the website, then navigate into the <codeph>bin</codeph> directory and run the <codeph>spark-shell</codeph> command:</p>
 

--- a/content/connectors/spark-1.0/spark-shell.dita
+++ b/content/connectors/spark-1.0/spark-shell.dita
@@ -12,6 +12,8 @@
 
 			<p>The Spark shell provides an easy and convenient way to prototype certain operations quickly,
 				without having to develop a full program, packaging it and then deploying it.</p>
+			
+			<note>Upgrade now to <xref href="https://developer.couchbase.com/documentation/server/current/connectors/spark-2.0/spark-intro.html" format="html" scope="external" >Couchbase Spark Connector 2.0</xref>.</note>
 
 			<p>You need to <xref href="https://spark.apache.org/downloads.html" format="html" scope="external">download</xref> Apache Spark from the website, then navigate into the <codeph>bin</codeph> directory and run the <codeph>spark-shell</codeph> command:</p>
 

--- a/content/connectors/spark-2.0/spark-intro.dita
+++ b/content/connectors/spark-2.0/spark-intro.dita
@@ -7,14 +7,14 @@
 <conbody>
 		<section>
 			<title>Compatibility</title>
-			<p>Every version of the Couchbase Spark connector is compiled against a specific Spark target.
+			<p>Every version of the Couchbase Spark Connector is compiled against a specific Spark target.
 				The following table lists the compatible versions:</p>
 			<table>
-				<title>Couchbase Spark connector compatibility</title>
+				<title>Couchbase Spark Connector Compatibility</title>
 				<tgroup cols="2">
 					<thead>
 						<row>
-							<entry>Couchbase Spark connector version</entry>
+							<entry>Couchbase Spark Connector version</entry>
 							<entry>Apache Spark target version</entry>
 						</row>
 					</thead>
@@ -45,9 +45,9 @@
 		</section>
 		<section>
 			<title>Contributing</title>
-			<p>Couchbase welcomes community contributions to the Spark connector. The <xref
+			<p>Couchbase welcomes community contributions to the Spark Connector. The <xref
 					href="https://github.com/couchbase/couchbase-spark-connector" format="html"
-					scope="external">Spark connector source code</xref> is available on GitHub and
+					scope="external">Spark Connector source code</xref> is available on GitHub and
 				contains instructions to contribute.</p>
 		</section>
 	</conbody>

--- a/content/connectors/spark-2.0/spark-shell.dita
+++ b/content/connectors/spark-2.0/spark-shell.dita
@@ -3,7 +3,7 @@
   PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="concept227">
 	<title>Using the Spark Shell</title>
-	<shortdesc>The interactive shell can be used together with the couchbase connector for quick and easy data exploration.</shortdesc>
+	<shortdesc>The interactive shell can be used together with the Couchbase Connector for quick and easy data exploration.</shortdesc>
 
 	<conbody>
 


### PR DESCRIPTION
This is very popular search result page for our docs, possibly due to general search for "spark shell".  
Adding a Note to the page to point to updated connector version should help guide people to newer content.