### PR TITLE
Update durability.dita

### DIFF
--- a/content/sdk/durability.dita
+++ b/content/sdk/durability.dita
@@ -76,8 +76,8 @@
             </ul><p>When an operation is propagated to a replica, it is first propagated to the
                 replica’s memory and then placed in a queue (as above) to be persisted to the
                 replica’s disk. You can control whether you desire the operation to only be
-                propagated to a replica’s memory (<codeph>persist to</codeph>), or whether to wait
-                until it is fully persisted to the replica’s disk (<codeph>replicate
+                propagated to a replica’s memory (<codeph>replicate to</codeph>), or whether to wait
+                until it is fully persisted to the replica’s disk (<codeph>persist
                 to</codeph>).</p><p><option>persist to</option> receives a value total to the number
                 of nodes that an operation should be persisted. The maximum value is the number of
                 replica nodes plus one. A value of 1 indicates master-only persistence (and no


### PR DESCRIPTION
I guess the options were misplaced:
"replica to" as far as I undestood is when the change is propagated to the remote replica memory, but not persisted
"persist to" is when the change is propagated to remote replica memory (except master case) and also written to disk (i.e. this flag is a stronger durability option than replica to", but for the master case)
Ths is clear from version 4.0
https://developer.couchbase.com/documentation/server/4.0/sdks/java-2.2/durability.html
"bucket.remove("docid", PersistTo.TWO);

In this last example also specifying ReplicateTo.ONE would be redundant, since persisting on a replica means it first needs to be replicated to it."