### PR TITLE
Update dotnet core logging with NLog example

### DIFF
--- a/content/sdk/dotnet/collecting-information-and-logging.dita
+++ b/content/sdk/dotnet/collecting-information-and-logging.dita
@@ -56,7 +56,7 @@
         &lt;appender-ref ref="FileAppender" />
     &lt;/root>
   &lt;/log4net>
-  
+
   &lt;startup>
     &lt;supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
   &lt;/startup>
@@ -75,13 +75,12 @@
           href="https://github.com/aspnet/Logging" format="html" scope="external">here</xref>. There
         are also some basic Microsoft provided adapters such as Debug, Console and EventLog.</p>
       <p>The following instructions show how to get up and running with the NLog adapter with the
-        SDK in an ASP.NET 5 web application:<ol id="ol_ef3_z1c_py">
-          <li>Add the following two dependencies to your
-            <codeph>project.json</codeph>:<codeblock outputclass="language-json">"dependencies": {
-  "NLog.Extensions.Logging": "1.0.0-*",
-  "CouchbaseNetClient": "2.4.0"
-}</codeblock></li>
-          <li>Create a nlog.config in the root of your project, an example config could look like
+        SDK in an ASP.NET 5 web application using the newer Visual Studio 2017 format:<ol
+          id="ol_ef3_z1c_py">
+          <li>Add the following two nuget dependencies: <i>CouchbaseNetClient</i> and
+              <i>NLog.Web.AspNetCore</i>.</li>
+          <li>Create a <i>nlog.config</i> in the root of your project and enable copy to output
+            director. An example config could look like
             this:<codeblock outputclass="language-xml">&lt;?xml version="1.0" encoding="utf-8" ?>
 &lt;nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -89,30 +88,84 @@
       internalLogLevel="Warn"
       internalLogFile="c:\temp\internal-nlog.txt">
 
-  &lt;!-- define various log targets -->
-  &lt;targets>
-    &lt;!-- write logs to file -->
-    &lt;target xsi:type="File" name="ownFile-web" fileName="c:\temp\ownFile-web-${shortdate}.log"
-                 layout="${longdate}|${event-properties:item=EventId.Id}|${logger}|${uppercase:${level}}|${message} ${exception}" />
-   
-    &lt;target xsi:type="File" name="couchbase" fileName="c:\temp\couchbase-${shortdate}.log"
-             layout="${longdate}|${event-properties:item=EventId.Id}|${logger}|${uppercase:${level}}|  ${message} ${exception}" />
-  &lt;/targets>
+	&lt;!-- Load the ASP.NET Core plugin -->
+	&lt;extensions>
+		&lt;add assembly="NLog.Web.AspNetCore"/>
+	&lt;/extensions>
 
-  &lt;rules>
-    &lt;logger name="Couchbase.*" minlevel="Trace" writeTo="couchbase" final="true" />
-    &lt;logger name="*" minlevel="Trace" writeTo="ownFile-web" />
-  &lt;/rules>
-&lt;/nlog></codeblock></li>
-          <li>in startup.cs update<codeph>Configure</codeph> with the
-            following:<codeblock outputclass="language-csharp">using NLog.Extensions.Logging;
-using Couchbase.Logging;
+	&lt;!-- the targets to write to -->
+	&lt;targets>
+		&lt;!-- write logs to file -->
+		&lt;target xsi:type="File" name="allfile" fileName="c:\temp\nlog-all-${shortdate}.log"
+		        layout="${longdate}|${event-properties:item=EventId.Id}|${logger}|${uppercase:${level}}|${message} ${exception}" />
 
-  public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
-  {
-      loggerFactory.AddNLog();
-      LogManager.ConfigureLoggerFactory(loggerFactory);
-      ...</codeblock></li>
+		&lt;!-- another file log, only own logs. Uses some ASP.NET core renderers -->
+		&lt;target xsi:type="File" name="ownFile-web" fileName="c:\temp\nlog-own-${shortdate}.log"
+		        layout="${longdate}|${event-properties:item=EventId.Id}|${logger}|${uppercase:${level}}|  ${message} ${exception}|url: ${aspnet-request-url}|action: ${aspnet-mvc-action}" />
+
+		&lt;!-- couchbase log file -->
+		&lt;target xsi:type="File" name="couchbase" fileName="c:\temp\couchbase-${shortdate}.log"
+		        layout="${longdate}|${event-properties:item=EventId.Id}|${logger}|${uppercase:${level}}|  ${message} ${exception}" />
+
+		&lt;!-- write to the void aka just remove -->
+		&lt;target xsi:type="Null" name="blackhole" />
+	&lt;/targets>
+
+	&lt;!-- rules to map from logger name to target -->
+	&lt;rules>
+		&lt;!--All logs, including from Microsoft-->
+		&lt;logger name="*" minlevel="Trace" writeTo="allfile" />
+
+		&lt;!--Skip Microsoft logs and so log only own logs-->
+		&lt;logger name="Microsoft.*" minlevel="Trace" writeTo="blackhole" final="true" />
+		&lt;logger name="Couchbase.*" minlevel="Trace" writeTo="couchbase" final="true" />
+		&lt;logger name="*" minlevel="Trace" writeTo="ownFile-web" />
+	&lt;/rules>
+&lt;/nlog>
+</codeblock></li>
+          <li>in startup.cs update both <i>Startup</i> and <i>Configure</i> methods to look like the
+            following:<codeblock outputclass="language-csharp">public Startup(IHostingEnvironment env)
+{
+    var builder = new ConfigurationBuilder()
+        .SetBasePath(env.ContentRootPath)
+        .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+        .AddEnvironmentVariables();
+    Configuration = builder.Build();
+
+    // register and load NLog config
+    env.ConfigureNLog("nlog.config");
+}
+
+public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+{
+    //add NLog to ASP.NET Core
+    loggerFactory.AddNLog();
+    LogManager.ConfigureLoggerFactory(loggerFactory);
+
+    //add NLog.Web plugin
+    app.AddNLogWeb();
+
+    app.UseMvc();
+}
+</codeblock></li>
+          <li>Inject a <i>ILogger</i> and write a log using the Microsoft Logger interface, for
+            example:<codeblock outputclass="language-csharp">public class HomeController : Controller
+{
+    private readonly ILogger _logger;
+
+    public HomeController(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    public IActionResult Index()
+    {
+        _logger.LogInformation("Index page says hello");
+        return View();
+    }
+}
+</codeblock></li>
         </ol></p>
       <p>More details on configuring NLog with Microsoft.Extensions.Logging can be found <xref
           href="https://github.com/NLog/NLog.Extensions.Logging" format="html" scope="external"


### PR DESCRIPTION
NLog updated the way ASP.NET 5 and .NET Core applications work which made our example not applicable.

This commit updates the example to use the new NLog setup.

This can be back-ported to previous versions. 