### PR TITLE
Add $ prefix to named variable in statement text

### DIFF
--- a/content/sdk/python/start-using-sdk.dita
+++ b/content/sdk/python/start-using-sdk.dita
@@ -89,7 +89,7 @@ bucket = Bucket('couchbase://hostname-or-ip/bucket-name')</codeblock>See
                 object and passing that to the <apiname>Bucket.n1ql_query()</apiname>
                 method<codeblock outputclass="language-python">from couchbase.n1ql import N1QLQuery
 query = N1QLQuery("SELECT airportname, city, country FROM `travel-sample `
-                  "WHERE type=\"airport\" AND city=my_city", my_city="Reno")
+                  "WHERE type=\"airport\" AND city=$my_city", my_city="Reno")
 for row in bucket.n1ql_query(query):
     print(row)</codeblock></p>
         </section>


### PR DESCRIPTION
Fixes typo in Python's getting started guide when using a named variable in N1QL query.