### PR TITLE
DOC-1733 Java SDK does not cover connection string in connection info

### DIFF
--- a/content/sdk/java/managing-connections.dita
+++ b/content/sdk/java/managing-connections.dita
@@ -26,6 +26,13 @@ Bucket bucket = cluster.openBucket("myapp", "password");]]></codeblock>
 <codeblock outputclass="language-java"><![CDATA[List<String> nodes = Arrays.asList("192.168.56.101", "192.168.56.102");
 Cluster cluster = CouchbaseCluster.create(nodes);]]></codeblock>
 
+<p>The Java SDK also offers limited support for creating a cluster from a Couchbase connection string:</p>			
+
+<codeblock outputclass="language-java"><![CDATA[String connectionString = "couchbase://192.168.56.101,192.168.56.102";
+CouchbaseCluster cluster = CouchbaseCluster.fromConnectionString(connectionString);]]></codeblock>
+
+<note type="warning">When creating a cluster from a connection string, the Java SDK ignores the scheme component; if a secure connection is desired, the Couchbase environment must be configured as described in <xref href="#concept2677/ssl" format="dita"/>. The Java SDK also ignores any options in the connection string, and will not work with a connection string that specifies a bucket name.</note>
+			
 <p>It is very important in a production setup to pass in at least two or three nodes of the cluster because if the first one in the list fails the other ones can be tried. After initial contact is made, the bootstrap list provided by the user is thrown away and replaced with a list provided by the server (which contains all nodes of the cluster).</p>
 
 <p>More buckets can be open at the same time if needed:</p>


### PR DESCRIPTION
Show how to create a cluster from a connection string using the Java SDK, and document the limitations of this technique.