### PR TITLE
DOC-2683: fixed 2 typos in install-swap-space.dita

### DIFF
--- a/content/install/install-swap-space.dita
+++ b/content/install/install-swap-space.dita
@@ -31,9 +31,9 @@
         <li>As Couchbase Server is a memory-first architecture, performance is gained (or at minimum
           not lost) just by changing the swappiness value to 0. <p>There are debates on many Linux
             forums about the merits of using either 0 or 1, but it is recommended to do your own
-            research. </p><p>The swappines value tells to the OS's virtual memory subsystem not swap
+            research. </p><p>The swappiness value tells to the OS's virtual memory subsystem not swap
             items from RAM to disk unless it really has to. If the cluster nodes are sized
-            correctly, swapping should not be necessary.</p><p>To change the swappines setting, use
+            correctly, swapping should not be necessary.</p><p>To change the swappiness setting, use
             sudo or just become root:
             <codeblock># Set the value for the running system
      sudo sh -c 'echo 0 > /proc/sys/vm/swappiness'


### PR DESCRIPTION
Fixed 2 typos in install-swap-space.dita for DOC-2683

2x "swappines" -> "swappiness"