### PR TITLE
Fix Spark version

### DIFF
--- a/content/connectors/spark-2.2/spark-intro.dita
+++ b/content/connectors/spark-2.2/spark-intro.dita
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="concept_l11_ppm_pp">
-	<title>Spark Connector 2.1</title>
+	<title>Spark Connector 2.2</title>
 	<shortdesc>The Couchbase Spark Connector provides first-class integration between your high performance Couchbase Server
 			cluster and the Apache Spark data processing platform.</shortdesc>
 <conbody>


### PR DESCRIPTION
We recently added a new section for Spark Connector 2.2, but forgot to update the title to reflect the new version.

(followup to d04e815ccf7385f0fd388562d6c110a040ef7b13)