### PR TITLE
Unclear n1ql rest API usage

### DIFF
--- a/content/n1ql/n1ql-rest-api/exauthhttp.dita
+++ b/content/n1ql/n1ql-rest-api/exauthhttp.dita
@@ -9,7 +9,7 @@
 <codeblock spectitle="Request:">
 $ curl -v http://localhost:8093/query/service \
 -d "statement=SELECT text FROM tweets LIMIT 1" \
--H "Authorization: Basic bG9jYWw6dHdlZXRzOnBBc3Mx"
+-u tweets:pAss1
 </codeblock>
      <codeblock spectitle="Response:">&lt; HTTP/1.1 200 OK
          {


### PR DESCRIPTION
Obviously the normal user doesn't type directly the authorization header, but instead he uses the curl "user (-u)" option instead.