### PR TITLE
Update C SDK documentation for document operations

### DIFF
--- a/content/sdk/c/document-operations.dita
+++ b/content/sdk/c/document-operations.dita
@@ -294,7 +294,7 @@ lcb_wait(instance);</codeblock>
                 <note>The expiry value is specified as a relative offset (in seconds) from the time
                     the server receives the operation. The expiry value can also be specified as an
                     absolute Unix timestamp. The server will assume that any value larger than
-                        <codeph>2592000</codeph> (i.e. one year, in seconds) is a Unix timestamp and
+                        <codeph>2592000</codeph> (i.e. one month, in seconds) is a Unix timestamp and
                     anything lower is a relative offset.</note>
             <codeblock outputclass="language-c">lcb_install_callback3(instance, LCB_CALLBACK_TOUCH, touch_handler);</codeblock>
             </p>You can also use the <codeph>generic_handler</codeph> defined above. There is no


### PR DESCRIPTION
TTL was incorrectly described as "one year, in seconds" when the value is in fact one month in seconds