### PR TITLE
Ready to merge: Update security-saslauthd-new.dita

### DIFF
--- a/content/security/security-saslauthd-new.dita
+++ b/content/security/security-saslauthd-new.dita
@@ -22,9 +22,16 @@
       <p>Install your Unix operating system with the package that is supported for LDAP integration. </p>
       <dl>
         <dlentry>
-          <dt>CentOS 6</dt>
+          <dt>CentOS 7</dt>
           <dd>
             <p><codeph>saslauthd 2.1.26</codeph> or higher</p>
+          </dd>
+        </dlentry>
+      </dl><dl>
+        <dlentry>
+          <dt>CentOS 6</dt>
+          <dd>
+            <p><codeph>saslauthd 2.1.23</codeph> or higher</p>
           </dd>
         </dlentry>
       </dl><dl>


### PR DESCRIPTION
Quick fix for DOC-2574:
"Version required of 'cyrus-sasl' for CentOS 6 is incorrect"

added CentOS 7, and changed CentOS 6's saslauthd version.