### PR TITLE
Ready to Merge: Added summaries for SysAdmins, with ports needed open for each task (…

### DIFF
--- a/content/install/install-ports.dita
+++ b/content/install/install-ports.dita
@@ -299,6 +299,30 @@
 					either of these ports, the Couchbase Server service will not start. </note></li>
 			
 		</ul>
+		<p>In summary, for the following, respective tasks, open these listed ports in your firewall.</p>
+		<dl>
+			<dlentry>
+				<dt>Node-to-node</dt>
+				<dd>For communication between all nodes within the cluster, you won't normally be using a firewall but these are the ports used:</dd>
+				<dd>4369, 8091, 8092, 8093, 8094 (Couchbase Server 4.5 and upwards), 9100, 9101, 9102, 9103, 9104, 9105, 9999, 11209, 11210, 18093, 21100-21299 (inclusive).</dd>
+			</dlentry>
+					<dlentry>
+				<dt>Node-to-client</dt>
+				<dd>8091, 8092, 8093, 8094 (Couchbase Server 4.5 and upwards), 11207, 11210, 11211, 18091, 18092, 18093.</dd>
+			</dlentry>
+			<dlentry>
+				<dt>Cluster administration</dt>
+				<dd>8091, 8094 (Couchbase Server 4.5 and upwards), 9102, 9998, 18091.</dd>
+			</dlentry>
+			<dlentry>
+				<dt>XDCR v1 (CAPI)</dt>
+				<dd>8091, 8092, 8093, 9998, 18093.</dd>
+			</dlentry>
+			<dlentry>
+				<dt>XDCR v2 (XMEM)</dt>
+				<dd>8091, 8092, 8093, 9998, 11207 (when SSL used), 11210, 11214, 11215, 18091, 18092, 18093.</dd>
+			</dlentry>
+		</dl>
 <section><title>User-Defined Ports</title>
 	<p>You can install and run Couchbase Server with user-defined ports rather than with the default ports.</p>
 	<note type="important">If you want to run Couchbase Server on user-defined ports and with multiple


### PR DESCRIPTION
…node-to-node, XDCR, etc.).
As the tasks are mutually exclusive, <task> would have been wrong - but neither gloss nor dlentry felt quite right either.