### PR TITLE
Remove errant bullet point

### DIFF
--- a/content/release-notes/relnotes.dita
+++ b/content/release-notes/relnotes.dita
@@ -17,10 +17,10 @@
             to access using RBAC. See <xref
               href="../security/concepts-rba-for-apps.dita#rbac_for_users_roles_and_privileges"
               >Bucket Full Access</xref> for details.</li>
-            <note type="important"> Many 5.0 features require the latest versions of Couchbase SDK.
+            <li>Important: Many 5.0 features require the latest versions of Couchbase SDK.
               It is critical to update the SDK before updating to 5.0. Upgrade according to the SDK
               versions listed in the <xref href="#topic_gbk_tyh_t5/sdk-compatibility" format="dita"
-                >SDK Compatibility</xref> chart below.</note>
+                >SDK Compatibility</xref> chart below.</li>
           <li>The TAP protocol which was previously deprecated, is now removed. TAP is an internal
             protocol that streams information about data changes between cluster nodes. TAP is
             replaced with a new protocol called Database Change Protocol (<xref

--- a/content/release-notes/relnotes.dita
+++ b/content/release-notes/relnotes.dita
@@ -17,12 +17,10 @@
             to access using RBAC. See <xref
               href="../security/concepts-rba-for-apps.dita#rbac_for_users_roles_and_privileges"
               >Bucket Full Access</xref> for details.</li>
-          <li>
             <note type="important"> Many 5.0 features require the latest versions of Couchbase SDK.
               It is critical to update the SDK before updating to 5.0. Upgrade according to the SDK
               versions listed in the <xref href="#topic_gbk_tyh_t5/sdk-compatibility" format="dita"
                 >SDK Compatibility</xref> chart below.</note>
-          </li>
           <li>The TAP protocol which was previously deprecated, is now removed. TAP is an internal
             protocol that streams information about data changes between cluster nodes. TAP is
             replaced with a new protocol called Database Change Protocol (<xref


### PR DESCRIPTION
It appears that the "Important" not should be a point on it's own, however this renders strangely 
<img width="865" alt="screen shot 2017-10-24 at 10 43 11" src="https://user-images.githubusercontent.com/6731951/31959018-67627d78-b8a8-11e7-87c8-e0fd691ca7b2.png">

Copying the format of the "Remember" note below should fix this.
