### PR TITLE
PYCBC-403: Define supported Python platforms.

### DIFF
--- a/content/sdk/python/compatibility-versions-features.dita
+++ b/content/sdk/python/compatibility-versions-features.dita
@@ -1,170 +1,198 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
-<topic id="topic_xx5_sl5_qv">
-    <title>Compatibility</title>
-    <!--<titlealts><navtitle>Compatibility</navtitle></titlealts>-->
-  <body>
-      <section>
-          <title>Couchbase Version/SDK Version Matrix</title>
-          <p>Couchbase SDKs are tested against a variety of different environments to ensure both
-              backward and forward compatibility with different versions of Couchbase Server. The matrix
-              below denotes the version of Couchbase Server, the version of the Python SDK and whether the SDK
-              is: <ul id="ul_mdv_42h_hw">
-                  <li> ✖ <b>Unsupported</b>: This combination is not tested, and is not within the scope of
-                      technical support if you have purchased a support agreement. </li>
-                  <li> ◎ <b>Compatible</b>: This combination has been tested previously, and should be
-                      compatible. This combination is not supported or recommended by our technical support
-                      organization. It is best to upgrade either the SDK or the Couchbase version you are
-                      using. </li>
-                  <li> ✔ <b>Supported</b>:This combination is subject to ongoing quality assurance, and is
-                      fully supported by our technical support organization. </li>
-              </ul></p>
-          <table frame="all" rowsep="1" colsep="1" id="table_sdk_versions">
-              <title>Couchbase Python SDK and Couchbase Server Compatibility Version Matrix</title>
-              <tgroup cols="3">
-                  <colspec colname="c1" colnum="1" colwidth="1*"/>
-                  <colspec colname="c2" colnum="2" colwidth="1*"/>
-                  <colspec colname="c3" colnum="3" colwidth="1*"/>
-                  <thead>
-                      <row>
-                          <entry><i>CB/SDK</i></entry>
-                          <entry><b>SDK 2.0</b></entry>
-                          <entry><b>SDK 2.1</b></entry>
-                      </row>
-                  </thead>
-                  <tbody>
-                      <row>
-                          <entry><b>CB 2.5</b></entry>
-                          <entry><b>◎</b></entry>
-                          <entry><b>◎</b></entry>
-                      </row>
-                      <row>
-                          <entry><b>CB 3.0</b></entry>
-                          <entry><b>◎</b></entry>
-                          <entry><b>◎ </b></entry>
-                      </row>
-                      <row>
-                          <entry><b>CB 3.1</b></entry>
-                          <entry><b>◎</b></entry>
-                          <entry><b>✔</b></entry>
-                      </row>
-                      <row>
-                          <entry><b>CB 4.0</b></entry>
-                          <entry><b>✔</b></entry>
-                          <entry><b>✔</b></entry>
-                      </row>
-                      <row>
-                          <entry><b>CB 4.1</b></entry>
-                          <entry><b>✔</b></entry>
-                          <entry><b>✔</b></entry>
-                      </row>
-                      <row>
-                          <entry><b>CB 4.5</b></entry>
-                          <entry><b>✔</b></entry>
-                          <entry><b>✔</b></entry>
-                      </row>
-                      <row>
-                          <entry><b>CB 4.6</b></entry>
-                          <entry><b>✔</b></entry>
-                          <entry><b>✔</b></entry>
-                      </row>
-                  </tbody>
-              </tgroup>
-          </table>
-      </section>
-        <section>
-            <title>Feature Compatibility</title>
-            <p>To take advantage of all features offered by Couchbase Server, you need to know what
-                version of the client provides compatibility for the features you want to use. The
-                following matrix shows which versions of the Python client support the major
-                features of each version of Couchbase Server.</p>
-            <p>Note that some of the features are dependent on the underlying C library
-                    (<i>libcouchbase</i>).</p>
-            <p>
-                <table frame="all" rowsep="1" colsep="1" id="table_cpq_bq5_qv">
-                    <title>Couchbase Server and SDK Supported Version Matrix</title>
-                    <tgroup cols="8" align="left">
-                        <colspec colname="feature" colnum="1" colwidth="1.2*"/>
-                        <colspec colname="v18" colnum="2" colwidth="1.0*"/>
-                        <colspec colname="v20" colnum="3" colwidth="1.0*"/>
-                        <colspec colname="v25" colnum="4" colwidth="1.0*"/>
-                        <colspec colname="v30" colnum="5" colwidth="1.0*"/>
-                        <colspec colname="v40" colnum="6" colwidth="1.0*"/>
-                        <colspec colname="v45" colnum="7" colwidth="1.0*"/>
-                        <colspec colname="v46" colnum="8" colwidth="1.0*"/>
-                        <thead>
-                            <row>
-                                <entry>Feature</entry>
-                                <entry>Server 1.8</entry>
-                                <entry>Server 2.0</entry>
-                                <entry>Server 2.5</entry>
-                                <entry>Server 3.0</entry>
-                                <entry>Server 4.0</entry>
-                                <entry>Server 4.5</entry>
-                                <entry>Server 4.6</entry>
-                            </row>
-                        </thead>
-                        <tbody>
-                            <row>
-                                <entry namest="feature" nameend="v46"><b>Basic features</b></entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="feature">CRUD operations</entry>
-                                <entry namest="v18" nameend="v46">Since 1.0</entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="feature">View Querying APIs</entry>
-                                <entry namest="v18" nameend="v46">Since 1.0</entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="v46"><b>Advanced features</b></entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="feature">Durability Requirements</entry>
-                                <entry namest="v18" nameend="v46">Since 1.1.0/<i>libcouchbase</i>
-                                    2.3.0</entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="feature">Fast (CCCP) Bootstrapping</entry>
-                                <entry namest="v18" nameend="v20">Not Supported</entry>
-                                <entry namest="v25" nameend="v46">Since <i>libcouchbase
-                                    2.3.0</i></entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="feature">SSL Connectivity</entry>
-                                <entry namest="v18" nameend="v25">Not Supported</entry>
-                                <entry namest="v30" nameend="v46">Since 2.0 / <i>libcouchbase
-                                    2.4.0</i></entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="feature">Bulk Operations</entry>
-                                <entry namest="v18" nameend="v46">Since 1.0</entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="feature">Cross-SDK Data types</entry>
-                                <entry namest="v18" nameend="v20">Not Supported</entry>
-                                <entry namest="v25" nameend="v46">Since 2.0</entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="feature">N1QL Querying</entry>
-                                <entry namest="v18" nameend="v30">Not Supported</entry>
-                                <entry namest="v40" nameend="v46">Since 2.0.1</entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="v46"><b>Administrative
-                                    Features</b></entry>
-                            </row>
-                            <row>
-                                <entry namest="feature" nameend="feature">Administrative API</entry>
-                                <entry namest="v18" nameend="v46">Not Supported</entry>
-                            </row>
-                        </tbody>
-                    </tgroup>
-                </table>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" ditaarch:DITAArchVersion="1.1" id="topic_xx5_sl5_qv">
+	<title>Compatibility</title>
+	<!--
+		&lt;titlealts&gt;&lt;navtitle&gt;Compatibility&lt;/navtitle&gt;&lt;/titlealts&gt;
+	-->
+	<body>
+		<section>
+			<title>Couchbase Version/SDK Version Matrix</title>
+			<p>
+				Couchbase SDKs are tested against a variety of different 
+				environments to ensure both backward and forward compatibility with 
+				different versions of Couchbase Server. The matrix below denotes 
+				the version of Couchbase Server, the version of the Python SDK and 
+				whether the SDK is:
+				<ul id="ul_mdv_42h_hw">
+					<li>
+						✖
+						<b>Unsupported</b>
+						: This combination is not tested, and is not within the scope of 
+						technical support if you have purchased a support agreement.
+					</li>
+					<li>
+						◎
+						<b>Compatible</b>
+						: This combination has been tested previously, and should be 
+						compatible. This combination is not supported or recommended by 
+						our technical support organization. It is best to upgrade either 
+						the SDK or the Couchbase version you are using.
+					</li>
+					<li>
+						✔
+						<b>Supported</b>
+						:This combination is subject to ongoing quality assurance, and is 
+						fully supported by our technical support organization.
+					</li>
+				</ul>
+			</p>
+			<table colsep="1" frame="all" id="table_sdk_versions" rowsep="1">
+				<title>Couchbase Python SDK and Couchbase Server Compatibility 
+				Version Matrix</title>
+				<tgroup cols="3">
+					<colspec colname="c1" colnum="1" colwidth="1*"/>
+					<colspec colname="c2" colnum="2" colwidth="1*"/>
+					<colspec colname="c3" colnum="3" colwidth="1*"/>
+					<thead>
+						<row><entry><i>CB/SDK</i></entry><entry><b>SDK 
+						2.0</b></entry><entry><b>SDK 2.1</b></entry></row>
+					</thead>
+					<tbody>
+						<row><entry><b>CB 
+						2.5</b></entry><entry><b>◎</b></entry><entry><b>◎</b></entry></row>
+						<row><entry><b>CB 
+						3.0</b></entry><entry><b>◎</b></entry><entry><b>◎</b></entry></row>
+						<row><entry><b>CB 
+						3.1</b></entry><entry><b>◎</b></entry><entry><b>✔</b></entry></row>
+						<row><entry><b>CB 
+						4.0</b></entry><entry><b>✔</b></entry><entry><b>✔</b></entry></row>
+						<row><entry><b>CB 
+						4.1</b></entry><entry><b>✔</b></entry><entry><b>✔</b></entry></row>
+						<row><entry><b>CB 
+						4.5</b></entry><entry><b>✔</b></entry><entry><b>✔</b></entry></row>
+						<row><entry><b>CB 
+						4.6</b></entry><entry><b>✔</b></entry><entry><b>✔</b></entry></row>
+					</tbody>
+				</tgroup>
+			</table>
+		</section>
+		<section>
+			<title>Feature Compatibility</title>
+			<p>To take advantage of all features offered by Couchbase Server, 
+			you need to know what version of the client provides compatibility 
+			for the features you want to use. The following matrix shows which 
+			versions of the Python client support the major features of each 
+			version of Couchbase Server.</p>
+			<p>
+				Note that some of the features are dependent on the underlying C 
+				library (
+				<i>libcouchbase</i>
+				).
+			</p>
+			<p>
+				<table colsep="1" frame="all" id="table_cpq_bq5_qv" rowsep="1">
+					<title>Couchbase Server and SDK Supported Version Matrix</title>
+					<tgroup align="left" cols="8">
+						<colspec colname="feature" colnum="1" colwidth="1.2*"/>
+						<colspec colname="v18" colnum="2" colwidth="1.0*"/>
+						<colspec colname="v20" colnum="3" colwidth="1.0*"/>
+						<colspec colname="v25" colnum="4" colwidth="1.0*"/>
+						<colspec colname="v30" colnum="5" colwidth="1.0*"/>
+						<colspec colname="v40" colnum="6" colwidth="1.0*"/>
+						<colspec colname="v45" colnum="7" colwidth="1.0*"/>
+						<colspec colname="v46" colnum="8" colwidth="1.0*"/>
+						<thead>
+							<row><entry>Feature</entry><entry>Server 
+							1.8</entry><entry>Server 2.0</entry><entry>Server 
+							2.5</entry><entry>Server 3.0</entry><entry>Server 
+							4.0</entry><entry>Server 4.5</entry><entry>Server 
+							4.6</entry></row>
+						</thead>
+						<tbody>
+							<row><entry nameend="v46" namest="feature"><b>Basic 
+							features</b></entry></row>
+							<row><entry nameend="feature" namest="feature">CRUD 
+							operations</entry><entry nameend="v46" namest="v18">Since 
+							1.0</entry></row>
+							<row><entry nameend="feature" namest="feature">View Querying 
+							APIs</entry><entry nameend="v46" namest="v18">Since 
+							1.0</entry></row>
+							<row><entry nameend="v46" namest="feature"><b>Advanced 
+							features</b></entry></row>
+							<row><entry nameend="feature" namest="feature">Durability 
+							Requirements</entry><entry nameend="v46" namest="v18">Since 
+							1.1.0/<i>libcouchbase</i>2.3.0</entry></row>
+							<row><entry nameend="feature" namest="feature">Fast (CCCP) 
+							Bootstrapping</entry><entry nameend="v20" namest="v18">Not 
+							Supported</entry><entry nameend="v46" namest="v25">Since<i>libcouchbase 
+							2.3.0</i></entry></row>
+							<row><entry nameend="feature" namest="feature">SSL 
+							Connectivity</entry><entry nameend="v25" namest="v18">Not 
+							Supported</entry><entry nameend="v46" namest="v30">Since 2.0 
+							/<i>libcouchbase 2.4.0</i></entry></row>
+							<row><entry nameend="feature" namest="feature">Bulk 
+							Operations</entry><entry nameend="v46" namest="v18">Since 
+							1.0</entry></row>
+							<row><entry nameend="feature" namest="feature">Cross-SDK Data 
+							types</entry><entry nameend="v20" namest="v18">Not 
+							Supported</entry><entry nameend="v46" namest="v25">Since 
+							2.0</entry></row>
+							<row><entry nameend="feature" namest="feature">N1QL 
+							Querying</entry><entry nameend="v30" namest="v18">Not 
+							Supported</entry><entry nameend="v46" namest="v40">Since 
+							2.0.1</entry></row>
+							<row><entry nameend="v46" namest="feature"><b>Administrative 
+							Features</b></entry></row>
+							<row><entry nameend="feature" namest="feature">Administrative 
+							API</entry><entry nameend="v46" namest="v18">Not 
+							Supported</entry></row>
+						</tbody>
+					</tgroup>
+				</table>
+			</p>
+		</section>
+		<section>
+			<title>Platform Compatibility</title>
+			<p>We support a number of Python versions on MacOS, Windows and 
+			Linux.
+            <ul id="ul_compat_legend">
+                    <li>
+                        ✖
+                        <b>Unsupported</b>
+                        : This combination is not tested, and is not within the scope of 
+                        technical support if you have purchased a support agreement.
+                    </li>
+                    <li>
+                        ◎
+                        <b>Compatible</b>
+                        : This combination has been tested previously, and should be 
+                        compatible. This combination is not supported or recommended by 
+                        our technical support organization. It is best to upgrade either 
+                        the SDK or the Couchbase version you are using.
+                    </li>
+                    <li>
+                        ✔
+                        <b>Supported</b>
+                        :This combination is subject to ongoing quality assurance, and is 
+                        fully supported by our technical support organization.
+                    </li>
+                </ul>
             </p>
-        </section>
-      <section conref="../interface-stability-pars.dita#toplevel/interface-stability-section">In the
-          Python SDK, the stability of an interface is listed in its API documentation as well as in
-          the headers themselves.</section>
-  </body>
+			<table colsep="1" frame="all" id="table_python_versions" rowsep="1">
+				<title>Couchbase Python SDK and Couchbase Server Compatibility 
+				Version Matrix</title>
+				<tgroup cols="3">
+					<colspec colname="c1" colnum="1" colwidth="1*"/>
+					<colspec colname="c2" colnum="2" colwidth="1*"/>
+					<colspec colname="c3" colnum="3" colwidth="1*"/>
+					<thead>
+						<row><entry><i>Python Version/SDK 
+						version</i></entry><entry><b>SDK 2.2.6</b></entry><entry><b>SDK 
+						2.3.0</b></entry></row>
+					</thead>
+					<tbody>
+						<row><entry><b>2.7</b></entry><entry><b>✔</b></entry><entry><b>✔</b></entry></row>
+						<row><entry><b>2.8</b></entry><entry><b>✔</b></entry><entry><b>✔</b></entry></row>
+						<row><entry><b>3.2</b></entry><entry><b>◎</b></entry><entry><b>✖</b></entry></row>
+						<row><entry><b>3.3</b></entry><entry><b>◎</b></entry><entry><b>◎</b></entry></row>
+						<row><entry><b>3.4</b></entry><entry><b>◎</b></entry><entry><b>◎</b></entry></row>
+						<row><entry><b>3.6</b></entry><entry><b>✔</b></entry><entry><b>✔</b></entry></row>
+					</tbody>
+				</tgroup>
+			</table>
+		</section>
+		<section conref="../interface-stability-pars.dita#toplevel/interface-stability-section">In 
+		the Python SDK, the stability of an interface is listed in its API 
+		documentation as well as in the headers themselves.</section>
+	</body>
 </topic>


### PR DESCRIPTION
Add a Python platform compatibility matrix.
Python 3.2 will not be supported for SDK 2.3.0 due to
deprecation by nosetest, PIP/setuptools teams, and is
generally considered EOL.