### PR TITLE
PYCBC-403: Define supported Python platforms.

### DIFF
--- a/content/sdk/interface-stability-pars.dita
+++ b/content/sdk/interface-stability-pars.dita
@@ -23,7 +23,7 @@
                         interfaces that are guaranteed to be supported and remain stable between SDK
                         versions.</li>
                     <li><b>Uncommitted</b>: This level is used to indicate APIs that are
-                            <i>unlikely</i> to change, but <i>may</i> still change as final consenus
+                            <i>unlikely</i> to change, but <i>may</i> still change as final consensus
                         on their behavior has not yet been reached. <i>Uncommitted</i> APIs usually
                         end up becoming stable APIs.</li>
                     <li><b>Volatile</b>: This level is used to indicate experimental APIs that are

--- a/content/sdk/python/compatibility-versions-features.dita
+++ b/content/sdk/python/compatibility-versions-features.dita
@@ -20,14 +20,14 @@
                       fully supported by our technical support organization. </li>
               </ul></p>
           <table frame="all" rowsep="1" colsep="1" id="table_sdk_versions">
-              <title>Couchbase Python SDK and Couchbase Server Compatibility Version Matrix</title>
+              <title>Couchbase Server and Python SDK Version Compatibility Matrix</title>
               <tgroup cols="3">
                   <colspec colname="c1" colnum="1" colwidth="1*"/>
                   <colspec colname="c2" colnum="2" colwidth="1*"/>
                   <colspec colname="c3" colnum="3" colwidth="1*"/>
                   <thead>
                       <row>
-                          <entry><i>CB/SDK</i></entry>
+                          <entry><i>Couchbase Server/Couchbase Python SDK</i></entry>
                           <entry><b>SDK 2.0</b></entry>
                           <entry><b>SDK 2.1</b></entry>
                       </row>
@@ -82,7 +82,7 @@
                     (<i>libcouchbase</i>).</p>
             <p>
                 <table frame="all" rowsep="1" colsep="1" id="table_cpq_bq5_qv">
-                    <title>Couchbase Server and SDK Supported Version Matrix</title>
+                    <title>Couchbase Server and Python SDK Feature Compatibility Matrix</title>
                     <tgroup cols="8" align="left">
                         <colspec colname="feature" colnum="1" colwidth="1.2*"/>
                         <colspec colname="v18" colnum="2" colwidth="1.0*"/>
@@ -191,14 +191,14 @@
                 </ul>
             </p>
             <table colsep="1" frame="all" id="table_python_versions" rowsep="1">
-                <title>Couchbase Python SDK and Couchbase Server Compatibility 
+                <title>Couchbase Python SDK and Python Version Compatibility 
                 Version Matrix</title>
                 <tgroup cols="3">
                     <colspec colname="c1" colnum="1" colwidth="1*"/>
                     <colspec colname="c2" colnum="2" colwidth="1*"/>
                     <colspec colname="c3" colnum="3" colwidth="1*"/>
                     <thead>
-                        <row><entry><i>Python Version/SDK 
+                        <row><entry><i>Python Version/Couchbase SDK 
                         version</i></entry><entry><b>SDK 2.2.6</b></entry><entry><b>SDK 
                         2.3.0</b></entry></row>
                     </thead>

--- a/content/sdk/python/compatibility-versions-features.dita
+++ b/content/sdk/python/compatibility-versions-features.dita
@@ -163,6 +163,55 @@
                 </table>
             </p>
         </section>
+        <section>
+            <title>Platform Compatibility</title>
+            <p>We support a number of Python versions on MacOS, Windows and 
+            Linux.
+                <ul id="ul_compat_legend">
+                    <li>
+                        ✖
+                        <b>Unsupported</b>
+                        : This combination is not tested, and is not within the scope of 
+                        technical support if you have purchased a support agreement.
+                    </li>
+                    <li>
+                        ◎
+                        <b>Compatible</b>
+                        : This combination has been tested previously, and should be 
+                        compatible. This combination is not supported or recommended by 
+                        our technical support organization. It is best to upgrade either 
+                        the SDK or the Couchbase version you are using.
+                    </li>
+                    <li>
+                        ✔
+                        <b>Supported</b>
+                        :This combination is subject to ongoing quality assurance, and is 
+                        fully supported by our technical support organization.
+                    </li>
+                </ul>
+            </p>
+            <table colsep="1" frame="all" id="table_python_versions" rowsep="1">
+                <title>Couchbase Python SDK and Couchbase Server Compatibility 
+                Version Matrix</title>
+                <tgroup cols="3">
+                    <colspec colname="c1" colnum="1" colwidth="1*"/>
+                    <colspec colname="c2" colnum="2" colwidth="1*"/>
+                    <colspec colname="c3" colnum="3" colwidth="1*"/>
+                    <thead>
+                        <row><entry><i>Python Version/SDK 
+                        version</i></entry><entry><b>SDK 2.2.6</b></entry><entry><b>SDK 
+                        2.3.0</b></entry></row>
+                    </thead>
+                    <tbody>
+                        <row><entry><b>2.7</b></entry><entry><b>✔</b></entry><entry><b>✔</b></entry></row>
+                        <row><entry><b>3.2</b></entry><entry><b>◎</b></entry><entry><b>✖</b></entry></row>
+                        <row><entry><b>3.3</b></entry><entry><b>◎</b></entry><entry><b>◎</b></entry></row>
+                        <row><entry><b>3.4</b></entry><entry><b>◎</b></entry><entry><b>◎</b></entry></row>
+                        <row><entry><b>3.6</b></entry><entry><b>✔</b></entry><entry><b>✔</b></entry></row>
+                    </tbody>
+                </tgroup>
+            </table>
+        </section>
       <section conref="../interface-stability-pars.dita#toplevel/interface-stability-section">In the
           Python SDK, the stability of an interface is listed in its API documentation as well as in
           the headers themselves.</section>


### PR DESCRIPTION
Add a Python platform/SDK support matrix and OS support info.
Python 3.2 will not be supported for SDK 2.3.0 due to
deprecation by nosetest, PIP/setuptools teams, and is
generally considered EOL.