### PR TITLE
The incorrect sample was corrected

### DIFF
--- a/content/sdk/java/async-programming.dita
+++ b/content/sdk/java/async-programming.dita
@@ -729,6 +729,7 @@ Observable
                 can use this approach to fall back:</p>
 
 <codeblock outputclass="language-java"><![CDATA[bucket
+    .async() 	
     .get("id")
     .onErrorResumeNext(bucket.getFromReplica("id", ReplicaMode.ALL))
     .subscribe();]]></codeblock>
@@ -738,6 +739,7 @@ Observable
 					<codeph>TimeoutException</codeph> happened (if not the error is passed down):</p>
 
 <codeblock outputclass="language-java"><![CDATA[bucket
+    .async() 
     .get("id")
     .timeout(500, TimeUnit.MILLISECONDS)
     .onErrorResumeNext(new Func1<Throwable, Observable<? extends JsonDocument>>() {


### PR DESCRIPTION
After bucket.get ("id") operation, timeout is only possible with asynchronous use.