### PR TITLE
Redirect old links to sdk sample-application

### DIFF
--- a/content/getting-started/index.dita
+++ b/content/getting-started/index.dita
@@ -12,7 +12,7 @@
 				<li>
 					<xref href="first-n1ql-query.dita#first-n1ql">Run N1QL queries</xref> by using the
 					command-line query tool, <cmdname>cbq</cmdname></li>
-				<li><xref href="../travel-app/index.dita">Run a sample web application</xref> that retrieves data from Couchbase Server</li>
+				<li><xref href="../sdk/sample-application.dita">Run a sample web application</xref> that retrieves data from Couchbase Server</li>
 			</ul>
 		</p>
 	

--- a/content/install/docker-deploy-multi-node-cluster.dita
+++ b/content/install/docker-deploy-multi-node-cluster.dita
@@ -68,7 +68,7 @@ docker inspect --format '{{ .NetworkSettings.IPAddress }}' db2</codeblock></li>
         each node is registered using the local IP address, applications using the SDK need to be
         within the private IP network the Couchbase Server containers are in. You can do this by
         running your application in another container on the same physical machine.</p><p>For more information on deploying a sample application to a container, see  <xref
-          href="../travel-app/index.dita"/>. </p>
+          href="../sdk/sample-application.dita"/>. </p>
     </section>
     <section><title>Deploying Couchbase Server Containers across Many Physical Machines</title>
       <p>In this deployment model each container is placed on its own physical machine. This is the supported model for production deployments with Couchbase Server containers.</p>

--- a/content/install/docker-deploy-single-node-cluster.dita
+++ b/content/install/docker-deploy-single-node-cluster.dita
@@ -39,7 +39,7 @@
     </section>
     <section><title>Connect via SDK</title>
       <p>Simply run your application through the Couchbase Server SDKs on the host and point it to <filepath>http://localhost:8091/pools</filepath> to connect to the container.</p>
-      <p>For information on deploying a sample application to a container, see <xref href="../travel-app/index.dita"></xref>. </p>
+      <p>For information on deploying a sample application to a container, see <xref href="../sdk/sample-application.dita"></xref>. </p>
     </section>
   </body>
 </topic>

--- a/content/install/getting-started-docker.dita
+++ b/content/install/getting-started-docker.dita
@@ -50,7 +50,7 @@
     </section>
     <section><title>Connect via SDK</title>
       <p>Simply run your application through the Couchbase Server SDKs on the host and point it to <filepath>http://localhost:8091/pools</filepath> to connect to the container.</p>
-      <p>For running a sample application, see <xref href="../travel-app/index.dita"></xref>. </p>
+      <p>For running a sample application, see <xref href="../sdk/sample-application.dita"></xref>. </p>
     </section>
   </body>
 </topic>

--- a/content/n1ql/n1ql-language-reference/insert.dita
+++ b/content/n1ql/n1ql-language-reference/insert.dita
@@ -71,7 +71,7 @@ RETURNING META().id as docid, *;</codeblock>
         examples in this topic. See <xref
           href="../../settings/install-sample-buckets.dita#topic_jqr_1rn_vs"/> for information on
         how to install the sample buckets and <xref
-          href="../../travel-app/travel-app-data-model.dita#concept_hyy_k1z_pr"/> for details about
+          href="../../sdk/sample-application.html#story-h2-3"/> for details about
         the travel-sample data model.</p>
       <p><b>Security Requirements</b></p>
       <p>You should have read-write permission to the bucket, to be able to insert documents into a

--- a/content/n1ql/n1ql-language-reference/insert.dita
+++ b/content/n1ql/n1ql-language-reference/insert.dita
@@ -71,7 +71,7 @@ RETURNING META().id as docid, *;</codeblock>
         examples in this topic. See <xref
           href="../../settings/install-sample-buckets.dita#topic_jqr_1rn_vs"/> for information on
         how to install the sample buckets and <xref
-          href="../../sdk/sample-application.dita#story-h2-3"/> for details about
+          href="../../sdk/sample-application.dita#story-h2-3">Sample Application</xref> for details about
         the travel-sample data model.</p>
       <p><b>Security Requirements</b></p>
       <p>You should have read-write permission to the bucket, to be able to insert documents into a

--- a/content/n1ql/n1ql-language-reference/insert.dita
+++ b/content/n1ql/n1ql-language-reference/insert.dita
@@ -71,7 +71,7 @@ RETURNING META().id as docid, *;</codeblock>
         examples in this topic. See <xref
           href="../../settings/install-sample-buckets.dita#topic_jqr_1rn_vs"/> for information on
         how to install the sample buckets and <xref
-          href="../../sdk/sample-application.html#story-h2-3"/> for details about
+          href="../../sdk/sample-application.dita#story-h2-3"/> for details about
         the travel-sample data model.</p>
       <p><b>Security Requirements</b></p>
       <p>You should have read-write permission to the bucket, to be able to insert documents into a

--- a/content/n1ql/n1ql-language-reference/selectintro.dita
+++ b/content/n1ql/n1ql-language-reference/selectintro.dita
@@ -265,7 +265,7 @@ WHERE  type = "airport"
               clause or subqueries.</p><b>JOIN Clause</b><p>Before we delve into examples, let's
               take a look at the data model of the travel-sample keyspace, which is used in the
               following examples. For more details about the data model, see <xref
-                href="../../travel-app/travel-app-data-model.dita#concept_hyy_k1z_pr"/>.<fig
+                href="../../sdk/sample-application.html#story-h2-3"/>.<fig
                 id="fig_fgp_14k_dx">
                 <title>Data model of travel-sample keyspace</title>
                 <image placement="break" href="../../travel-app/images/travel-app-data-model.png"

--- a/content/n1ql/n1ql-language-reference/selectintro.dita
+++ b/content/n1ql/n1ql-language-reference/selectintro.dita
@@ -265,7 +265,7 @@ WHERE  type = "airport"
               clause or subqueries.</p><b>JOIN Clause</b><p>Before we delve into examples, let's
               take a look at the data model of the travel-sample keyspace, which is used in the
               following examples. For more details about the data model, see <xref
-                href="../../sdk/sample-application.html#story-h2-3"/>.<fig
+                href="../../sdk/sample-application.dita#story-h2-3"/>.<fig
                 id="fig_fgp_14k_dx">
                 <title>Data model of travel-sample keyspace</title>
                 <image placement="break" href="../../travel-app/images/travel-app-data-model.png"

--- a/content/n1ql/n1ql-language-reference/selectintro.dita
+++ b/content/n1ql/n1ql-language-reference/selectintro.dita
@@ -265,7 +265,7 @@ WHERE  type = "airport"
               clause or subqueries.</p><b>JOIN Clause</b><p>Before we delve into examples, let's
               take a look at the data model of the travel-sample keyspace, which is used in the
               following examples. For more details about the data model, see <xref
-                href="../../sdk/sample-application.dita#story-h2-3"/>.<fig
+                href="../../sdk/sample-application.dita#story-h2-3">Sample Application</xref>.<fig
                 id="fig_fgp_14k_dx">
                 <title>Data model of travel-sample keyspace</title>
                 <image placement="break" href="../../travel-app/images/travel-app-data-model.png"


### PR DESCRIPTION
I think I caught them all: docs were previously moved or consolidated from travel-app -> sdk/sample-application .  

@tonyjhillman do you think that covers off the changes you made earlier?