### PR TITLE
Removed out of place disadvantage

### DIFF
--- a/content/data-modeling/entity-relationship-doc-design.dita
+++ b/content/data-modeling/entity-relationship-doc-design.dita
@@ -54,18 +54,6 @@
      items, you may need to issue multiple operations causing multiple round trips. For
      example, with "brewery" document referencing "beer", adding a new "beer" requires an
      additional write to the referencing "brewery" document.</li>
-    <li>Couchbase Server provides ACID properties on document operations addressing a single
-     document. <ul>
-      <li>A single document write is guaranteed to either fully succeed or fail.</li>
-      <li>No operation can see a partially updated version of the document. </li>
-      <li>If update operation is issued with durability requirements such as replicated
-       durability (replicateTo) or persisted durability (persistTo flag), Couchbase Server
-       guarantees the whole document will be durable. </li>
-     </ul><p>Operations that require an update to beer and a brewery document cannot take
-      advantage of ACID properties. For example, if brewery document is embedded in beer
-      document and there could be many beers embedding the same brewery, you must search and
-      update all the beers that embed the targeted brewery. However, this cannot be done in
-      a single consistent operation.</p></li>
    </ul>
     <fig id="fig_zzl_yrt_dt">
      <title>Embedded versus referenced documents</title>


### PR DESCRIPTION
The feature explanation (ACID compliance) and the statement of disadvantage that is removed in the commit makes sense only in the context of Embedded documents. Not in the context of references. And the embedded documents section has a similar statement and appropriate example already.