### PR TITLE
[4.5] Replace all occurrences of Smart Quotes (“”)

### DIFF
--- a/content/analytics/2_expr.html
+++ b/content/analytics/2_expr.html
@@ -210,7 +210,7 @@ Index           ::= "[" ( Expression | "?" ) "]"
 <p>Components of complex types in the data model are accessed via path expressions. Path access can be applied to the result
 of a SQL++ expression that yields an instance of  a complex type, for example, a record or array instance. For records,
 path access is based on field names. For arrays, path access is based on (zero-based) array-style indexing.
-SQL++ also supports an “I’m feeling lucky” style index accessor, [?], for selecting an arbitrary element from an array.
+SQL++ also supports an "I’m feeling lucky" style index accessor, [?], for selecting an arbitrary element from an array.
  Attempts to access non-existent fields or out-of-bound array elements produce the special value <code class="highlighter-rouge">MISSING</code>.</p>
 
 <p>The following examples illustrate field access for a record, index-based element access for an array, and also a
@@ -466,12 +466,12 @@ composition thereof.</p>
     </tr>
     <tr>
       <td>LIKE</td>
-      <td>Test if the left side matches a<br /> pattern defined on the right<br /> side; in the pattern,  “%” matches  <br />any string while “_” matches <br /> any character.</td>
+      <td>Test if the left side matches a<br /> pattern defined on the right<br /> side; in the pattern,  "%" matches  <br />any string while "_" matches <br /> any character.</td>
       <td><code class="highlighter-rouge">SELECT * FROM ChirpMessages cm &lt;br/&gt;WHERE cm.user.name LIKE "%Giesen%";</code></td>
     </tr>
     <tr>
       <td>NOT LIKE</td>
-      <td>Test if the left side does not <br />match a pattern defined on the right<br /> side; in the pattern,  “%” matches <br />any string while “_” matches <br /> any character.</td>
+      <td>Test if the left side does not <br />match a pattern defined on the right<br /> side; in the pattern,  "%" matches <br />any string while "_" matches <br /> any character.</td>
       <td><code class="highlighter-rouge">SELECT * FROM ChirpMessages cm &lt;br/&gt;WHERE cm.user.name NOT LIKE "%Giesen%";</code></td>
     </tr>
   </tbody>

--- a/content/analytics/3_query.html
+++ b/content/analytics/3_query.html
@@ -199,7 +199,7 @@ The contents of the example collections are as follows:</p>
 <p>The SQL++ <code class="highlighter-rouge">SELECT</code> clause always returns a collection value as its result (even if the result is empty or a singleton).</p>
 
 <h3 id="a-idselectelementselect-value-clausea"><a id="Select_element">SELECT VALUE Clause</a></h3>
-<p>The <code class="highlighter-rouge">SELECT VALUE</code> clause in SQL++ returns a collection that contains the results of evaluating the <code class="highlighter-rouge">VALUE</code> expression, with one evaluation being performed per “binding tuple” (that is per <code class="highlighter-rouge">FROM</code> clause item) satisfying the statement’s selection criteria.
+<p>The <code class="highlighter-rouge">SELECT VALUE</code> clause in SQL++ returns a collection that contains the results of evaluating the <code class="highlighter-rouge">VALUE</code> expression, with one evaluation being performed per "binding tuple" (that is per <code class="highlighter-rouge">FROM</code> clause item) satisfying the statement’s selection criteria.
 For historical reasons, SQL++ also allows the keywords <code class="highlighter-rouge">ELEMENT</code> or <code class="highlighter-rouge">RAW</code> to be used in place of <code class="highlighter-rouge">VALUE</code> (not recommended).
 The following example shows a query that selects one user from the GleambookUsers collection.</p>
 
@@ -480,8 +480,8 @@ WHERE u.id = 1;
 <p>Note that if <code class="highlighter-rouge">u.hobbies</code> is an empty collection or leads to a <code class="highlighter-rouge">MISSING</code> (as above) or <code class="highlighter-rouge">NULL</code> value for a given input tuple, there is no corresponding binding value for variable <code class="highlighter-rouge">h</code> for an input tuple. A <code class="highlighter-rouge">MISSING</code> value will be generated for <code class="highlighter-rouge">h</code> so that the input tuple can still be propagated.</p>
 
 <h3 id="a-idexpressingjoinsusingunnestsexpressing-joins-using-unnesta"><a id="Expressing_joins_using_unnests">Expressing JOINs Using UNNEST</a></h3>
-<p>The SQL++ <code class="highlighter-rouge">UNNEST</code> clause is similar to SQL’s <code class="highlighter-rouge">JOIN</code> clause except that it allows its right argument to be correlated to its left argument, as in the examples above — that is, think “correlated cross-product”.
-The next example shows this via a query that joins two data sets, GleambookUsers and GleambookMessages, returning user/message pairs. The results contain one record per pair, with result records containing the user’s name and an entire message. The query can be thought of as saying “for each Gleambook user, unnest the <code class="highlighter-rouge">GleambookMessages</code> collection and filter the output with the condition <code class="highlighter-rouge">message.authorId = user.id</code>”.</p>
+<p>The SQL++ <code class="highlighter-rouge">UNNEST</code> clause is similar to SQL’s <code class="highlighter-rouge">JOIN</code> clause except that it allows its right argument to be correlated to its left argument, as in the examples above — that is, think "correlated cross-product".
+The next example shows this via a query that joins two data sets, GleambookUsers and GleambookMessages, returning user/message pairs. The results contain one record per pair, with result records containing the user’s name and an entire message. The query can be thought of as saying "for each Gleambook user, unnest the <code class="highlighter-rouge">GleambookMessages</code> collection and filter the output with the condition <code class="highlighter-rouge">message.authorId = user.id</code>".</p>
 
 <h5 id="example-9">Example</h5>
 
@@ -717,7 +717,7 @@ FROM GleambookUsers u LEFT OUTER JOIN GleambookMessages m ON m.authorId = u.id;
 </code></pre>
 </div>
 
-<p>For non-matching left-side tuples, SQL++ produces <code class="highlighter-rouge">MISSING</code> values for the right-side binding variables; that is why the last record in the above result doesn’t have a <code class="highlighter-rouge">message</code> field. Note that this is slightly different from standard SQL, which instead fills in <code class="highlighter-rouge">NULL</code> values for the right-side fields. The reason for this difference is that, for non-matches in its join results, SQL++ views fields from the right-side as being “not there” (also as <code class="highlighter-rouge">MISSING</code>) instead of as being “there but unknown” (that is, <code class="highlighter-rouge">NULL</code>).</p>
+<p>For non-matching left-side tuples, SQL++ produces <code class="highlighter-rouge">MISSING</code> values for the right-side binding variables; that is why the last record in the above result doesn’t have a <code class="highlighter-rouge">message</code> field. Note that this is slightly different from standard SQL, which instead fills in <code class="highlighter-rouge">NULL</code> values for the right-side fields. The reason for this difference is that, for non-matches in its join results, SQL++ views fields from the right-side as being "not there" (also as <code class="highlighter-rouge">MISSING</code>) instead of as being "there but unknown" (that is, <code class="highlighter-rouge">NULL</code>).</p>
 
 <p>The left-outer join query can also be expressed using <code class="highlighter-rouge">LEFT OUTER UNNEST</code>:</p>
 
@@ -858,7 +858,7 @@ appears in the <code class="highlighter-rouge">msg</code> field of the records i
 <p>The group variable in SQL++ makes more complex, composable, nested subqueries over a group possible, which is
 important given the more complex data model of SQL++ (relative to SQL).
 As a simple example of this, as you really just want the messages associated with each user, you may wish to avoid
-the “extra wrapping” of each message as the <code class="highlighter-rouge">msg</code> field of a record.
+the "extra wrapping" of each message as the <code class="highlighter-rouge">msg</code> field of a record.
 (That wrapping is useful in more complex cases, but is essentially just in the way here.)
 You can use a subquery in the <code class="highlighter-rouge">SELECT</code> clause to tunnel through the extra nesting and produce the desired result.</p>
 
@@ -964,8 +964,8 @@ GROUP BY message.authorId AS uid GROUP AS msgs(message AS msg);
 </code></pre>
 </div>
 
-<p>This variant of the query exploits a bit of SQL-style “syntactic sugar” that SQL++ offers to shorten some user queries.
-In particular, in the <code class="highlighter-rouge">SELECT</code> list, the reference to the <code class="highlighter-rouge">GROUP</code> variable field <code class="highlighter-rouge">msg</code> – because it references a field of the group variable – is allowed but is “pluralized”. As a result, the <code class="highlighter-rouge">msg</code> reference in the <code class="highlighter-rouge">SELECT</code> list is
+<p>This variant of the query exploits a bit of SQL-style "syntactic sugar" that SQL++ offers to shorten some user queries.
+In particular, in the <code class="highlighter-rouge">SELECT</code> list, the reference to the <code class="highlighter-rouge">GROUP</code> variable field <code class="highlighter-rouge">msg</code> – because it references a field of the group variable – is allowed but is "pluralized". As a result, the <code class="highlighter-rouge">msg</code> reference in the <code class="highlighter-rouge">SELECT</code> list is
 implicitly rewritten into the second variant’s <code class="highlighter-rouge">SELECT VALUE</code> subquery.</p>
 
 <p>The next example shows a more interesting case involving the use of a subquery in the <code class="highlighter-rouge">SELECT</code> list.
@@ -1246,7 +1246,7 @@ The following table catalogs the SQL++ built-in aggregation functions and also i
 <p>Note that SQL++ has twice as many functions listed above as there are aggregate functions in SQL-92.
 Since SQL++ offers two versions of each: one version handles <code class="highlighter-rouge">UNKNOWN</code> values in a semantically
 strict fashion, where unknown values in the input result in unknown values in the output, and the other version
-handles them in the ad hoc “just ignore the unknown values” fashion that the SQL standard chose to adopt.</p>
+handles them in the ad hoc "just ignore the unknown values" fashion that the SQL standard chose to adopt.</p>
 
 <h5 id="example-24">Example</h5>
 
@@ -1305,7 +1305,7 @@ GROUP BY msg.authorId AS uid;
 </div>
 
 <p>It is important to realize that <code class="highlighter-rouge">COUNT</code> is actually <strong>not</strong> a SQL++ built-in aggregation function.
-Rather, the <code class="highlighter-rouge">COUNT</code> query above is using a special “sugared” function symbol that the SQL++ compiler
+Rather, the <code class="highlighter-rouge">COUNT</code> query above is using a special "sugared" function symbol that the SQL++ compiler
 rewrites as follows:</p>
 
 <div class="highlighter-rouge"><pre class="highlight"><code>SELECT uid AS uid, ARRAY_COUNT( (SELECT g.msg FROM `$1` as g) ) AS msgCnt
@@ -1342,7 +1342,7 @@ GROUP BY msg.authorId;
 </code></pre>
 </div>
 
-<p>In principle, a <code class="highlighter-rouge">msg</code> reference in the query’s <code class="highlighter-rouge">SELECT</code> clause is “sugarized” as a collection
+<p>In principle, a <code class="highlighter-rouge">msg</code> reference in the query’s <code class="highlighter-rouge">SELECT</code> clause is "sugarized" as a collection
 (as described in <a href="#Implicit_group_variables">Implicit Group Variables</a>).
 However, since the SELECT expression <code class="highlighter-rouge">msg.authorId</code> is syntactically identical to a GROUP BY key expression,
 it is internally replaced by the generated group key variable.
@@ -1579,14 +1579,14 @@ WHERE LEN(user.friendIds) &gt;
 <p>The WITH clause can be particularly useful when a value needs to be used several times in a query.</p>
 
 <p>Before proceeding further, notice that both  the WITH query and its equivalent inlined variant
-include the syntax “[0]” - this is due to a noteworthy difference between SQL++ and SQL-92.
+include the syntax "[0]" - this is due to a noteworthy difference between SQL++ and SQL-92.
 In SQL-92, whenever a scalar value is expected and it is being produced by a query expression,
 the SQL-92 query processor will evaluate the expression, check that there is only one row and column
 in the result at runtime, and then coerce the one-row/one-column tabular result into a scalar value.
 SQL++, being designed to deal with nested data and schema-less data, does not (and should not) do this.
 Collection-valued data is perfectly legal in most SQL++ contexts, and its data is schema-less,
 so a query processor rarely knows exactly what to expect where and such automatic conversion is often
-not desirable. Thus, in the queries above, the use of “[0]” extracts the first (that is 0th) element of
+not desirable. Thus, in the queries above, the use of "[0]" extracts the first (that is 0th) element of
 an array-valued query expression’s result; this is needed above, even though the result is an array of one
 element, to extract the only element in the singleton array and obtain the desired scalar for the comparison.</p>
 
@@ -1734,7 +1734,7 @@ Unlike SQL-92, as was just alluded to, the subqueries in a SELECT list or a bool
 not return singleton, single-column relations.
 Instead, they may return arbitrary collections.
 For example, the following query is a variant of the prior group-by query examples;
-it retrieves an array of up to two “dislike” messages per user.</p>
+it retrieves an array of up to two "dislike" messages per user.</p>
 
 <h5 id="example-34">Example</h5>
 
@@ -1828,7 +1828,7 @@ within a query the subquery occurs, and again the result is never automatically 
 </table>
 
 <p>For items beyond this cheat sheet, SQL++ is compliant with SQL-92.
-Moreover, SQL++ offers the following additional features beyond SQL-92 (hence the “++” in its name):</p>
+Moreover, SQL++ offers the following additional features beyond SQL-92 (hence the "++" in its name):</p>
 
 <ul>
   <li>Fully composable and functional: A subquery can iterate over any intermediate collection and can appear anywhere in a query.</li>

--- a/content/analytics/6_n1ql.html
+++ b/content/analytics/6_n1ql.html
@@ -143,8 +143,8 @@ Data mutations must be performed using the Couchbase Server SDK or N1QL; those m
   <tbody>
     <tr>
       <td>IN</td>
-      <td><code class="highlighter-rouge">SELECT * FROM default_shadow WHERE  id IN (“1”, “2”);</code></td>
-      <td><code class="highlighter-rouge">SELECT * FROM default_shadow WHERE  id IN [“1”, “2”];</code></td>
+      <td><code class="highlighter-rouge">SELECT * FROM default_shadow WHERE  id IN ("1", "2");</code></td>
+      <td><code class="highlighter-rouge">SELECT * FROM default_shadow WHERE  id IN ["1", "2"];</code></td>
     </tr>
     <tr>
       <td>DISTINCT Aggregate</td>

--- a/content/analytics/diff-lang.dita
+++ b/content/analytics/diff-lang.dita
@@ -25,12 +25,12 @@
               <entry>
                 <codeblock>SELECT * 
 FROM default_shadow s 
-WHERE meta().id <b>IN</b> [“1”, “2”, “3”];</codeblock>
+WHERE meta().id <b>IN</b> ["1", "2", "3"];</codeblock>
               </entry>
               <entry>
                 <codeblock>SELECT * 
 FROM default_shadow s 
-WHERE <b>USE KEYS</b> [“1”, “2”, “3”];</codeblock>
+WHERE <b>USE KEYS</b> ["1", "2", "3"];</codeblock>
               </entry>
             </row>
             <row>
@@ -129,12 +129,12 @@ FROM system:&lt;indexes>;</codeblock>
               <entry dir="ltr">
                 <codeblock>SELECT * 
 FROM   default_shadow 
-WHERE  id IN [“1”, “2”];</codeblock>
+WHERE  id IN ["1", "2"];</codeblock>
               </entry>
               <entry dir="ltr">
                 <codeblock>SELECT * 
 FROM   default_shadow 
-WHERE  id IN (“1”, “2”);</codeblock>
+WHERE  id IN ("1", "2");</codeblock>
               </entry>
             </row>
             <row>

--- a/content/analytics/primer-beer.html
+++ b/content/analytics/primer-beer.html
@@ -600,7 +600,7 @@ LIMIT 20;
 </div>
 
 <p>The result of this query is a sequence of new records, one for each brewery/beer pair.
-Each instance in the result will be a record containing two fields, “brewer” and “beer”,
+Each instance in the result will be a record containing two fields, "brewer" and "beer",
 containing the brewery’s name and the beer’s name, respectively, for each brewery/beer pair.
 Notice how the use of a SQL-style <em>SELECT</em> clause, as opposed to the new SQL++ <em>SELECT VALUE</em>
 clause, automatically results in the construction of a new record value for each result.</p>
@@ -687,8 +687,8 @@ LIMIT 20;
 </div>
 
 <p>In SQL++, this <em>SELECT *</em> query will produce a new nested record for each user/message pair.
-Each result record contains one field (named after the “breweries” variable) to hold the brewery record
-and another field (named after the “beers” variable) to hold the matching beer record.
+Each result record contains one field (named after the "breweries" variable) to hold the brewery record
+and another field (named after the "beers" variable) to hold the matching beer record.
 Note that the nested nature of this SQL++ <em>SELECT *</em> result is different than traditional SQL,
 as SQL was not designed to handle the richer, nested data model that underlies the design of SQL++.</p>
 
@@ -700,7 +700,7 @@ as SQL was not designed to handle the richer, nested data model that underlies t
         "name": "(512) ALT",
         "upc": 0,
         "description": "(512) ALT is a German-style amber ale that is fermented cooler than
-        typical ales and cold conditioned like a lager. ALT means “old” in German and refers
+        typical ales and cold conditioned like a lager. ALT means "old" in German and refers
         to a beer style made using ale yeast after many German brewers had switched to newly
         discovered lager yeast. This ale has a very smooth, yet pronounced, hop bitterness
         with a malty backbone and a characteristic German yeast character. Made with 98% Organic 2-row
@@ -1450,7 +1450,7 @@ LIMIT 20;
 </div>
 
 <p>This version of the query uses an explicit record constructor to build each result record.
-Note that the string field names “bw” and “br” in the record constructor above are both simple SQL++
+Note that the string field names "bw" and "br" in the record constructor above are both simple SQL++
 expressions themselves, so in the most general case, even the resulting field names can be computed as part of the query,
 making SQL++ a very powerful tool for slicing and dicing semistructured data.</p>
 
@@ -1482,8 +1482,8 @@ LIMIT 5;
 </code></pre>
 </div>
 
-<p>This SQL++ query binds the variable “bw” to the records in breweries;
-for each brewery, it constructs a result record containing a “brewer” field with the brewery’s name plus a “beers”
+<p>This SQL++ query binds the variable "bw" to the records in breweries;
+for each brewery, it constructs a result record containing a "brewer" field with the brewery’s name plus a "beers"
 field with a nested collection of records containing the beer name and alcohol percentage for each of the brewery’s beers.
 The nested collection field for each brewery is created using a correlated subquery.</p>
 <blockquote>
@@ -1623,7 +1623,7 @@ efficient parallel join strategy when actually computing the query’s result.</
 </code></pre>
 </div>
 
-<p>Notice that since the brewery named “Abbey Wright Brewing/Valley Inn” offers no beers, its list of beers is empty.</p>
+<p>Notice that since the brewery named "Abbey Wright Brewing/Valley Inn" offers no beers, its list of beers is empty.</p>
 
 <h3 id="query-5---theta-join">Query 5 - Theta Join</h3>
 <p>Not all joins are expressible as equijoins and computable using equijoin-oriented algorithms.
@@ -2341,7 +2341,7 @@ LIMIT 3;
 <h3 id="everything-must-change">Everything Must Change</h3>
 <p>So far you have been walking through the SQL++ query capabilities of Analytics.
 What really makes Analytics interesting, however, is that it brings this query power to bear on your nearly-current Couchbase Server
-data, enabling you to harness the power of parallelism in Analytics to analyze what’s going on with your data “up front” in essentially
+data, enabling you to harness the power of parallelism in Analytics to analyze what’s going on with your data "up front" in essentially
 real time, without perturbing your Couchbase Server applications’ performance (or the resulting end user experience).
 Before closing this tutorial, let’s take a very quick look at that aspect of Analytics.</p>
 
@@ -2630,7 +2630,7 @@ in the <a href="function-ref.html">Function Reference</a>.</p>
 <p>Couchbase Analytics lets you bring a powerful new NoSQL parallel query engine to bear on your data, using the latest state of the art parallel query processing techniques under the hood. We hope you find it useful in exploring and analyzing your Couchbase Server data - without having to worry about end user performance impact or doing ETL grunt work to make your analyses possible.
 (Note that the DP1 demo set up does not effectively demonstrate the performance aspect of Analytics.)</p>
 
-<p>Use it wisely, and remember: “With great power comes great responsibility…” :-)</p>
+<p>Use it wisely, and remember: "With great power comes great responsibility…" :-)</p>
 
 <p>Do let us know how you like it…!</p>
 

--- a/content/introduction/whats-new.dita
+++ b/content/introduction/whats-new.dita
@@ -56,7 +56,7 @@
           <dlentry>
             <dt>New String Function SUFFIXES() for Efficient Pattern Matching</dt>
             <dd>The new function SUFFIXES() produces all possible suffix substrings of a given
-            string. For example, <codeph>SUFFIXES(“N1QL”)</codeph> produces the following array of
+            string. For example, <codeph>SUFFIXES("N1QL")</codeph> produces the following array of
             substrings: <codeph>SUFFIXES("N1QL") = [ "N1QL", "1QL", "QL", "L" ]</codeph>. <p>While
               the core functionality is simple, it is immensely helpful in improving the performance
               of pattern matching with LIKE "%substring%" queries. See <xref

--- a/content/n1ql/n1ql-language-reference/comparisonops.dita.bak
+++ b/content/n1ql/n1ql-language-reference/comparisonops.dita.bak
@@ -242,8 +242,8 @@
 
 		<p>String comparison is done using a raw-byte collation of UTF-8 encoded strings (sometimes
 			referred to as binary, C, or memcmp). This collation is case sensitive. Case-insensitive
-			comparisons can be performed using the UPPER() or LOWER() functions. See the “String
-			Functions” section for more information.</p>
+			comparisons can be performed using the UPPER() or LOWER() functions. See the "String
+			Functions" section for more information.</p>
 
 		<p>
 			<b>Arrays and Objects</b>

--- a/content/n1ql/n1ql-language-reference/select-syntax.dita
+++ b/content/n1ql/n1ql-language-reference/select-syntax.dita
@@ -15,8 +15,8 @@
         <image placement="break" href="images/select.png" id="image_jz2_3cl_dx"/>
       </fig></p>
     <p id="select-term"><codeph>select-term::= <xref href="#topic_vr1_zzk_dx/subselect"
-          format="dita">subselect</xref> | “(“ <xref href="#topic_vr1_zzk_dx/select" format="dita"
-          >select</xref> “)”</codeph></p>
+          format="dita">subselect</xref> | "(" <xref href="#topic_vr1_zzk_dx/select" format="dita"
+          >select</xref> ")"</codeph></p>
     <fig id="fig_drp_vfl_dx">
       <title>Railroad Diagram: select-term</title>
       <image placement="break" href="images/select-term.png" id="image_erp_vfl_dx"/>
@@ -64,8 +64,8 @@
       </fig>
       <p id="from-term"><codeph>from-term::= <xref href="#topic_vr1_zzk_dx/from-keyspace"
             format="dita">from-keyspace</xref> [ [ AS ] alias ] [ <xref
-            href="#topic_vr1_zzk_dx/use-clause" format="dita">use-clause</xref> ] | “(” <xref
-            href="#topic_vr1_zzk_dx/select" format="dita">select</xref> “)” [ AS ] alias | f<xref
+            href="#topic_vr1_zzk_dx/use-clause" format="dita">use-clause</xref> ] | "(" <xref
+            href="#topic_vr1_zzk_dx/select" format="dita">select</xref> ")" [ AS ] alias | f<xref
             href="#topic_vr1_zzk_dx/from-term" format="dita">from-term</xref> ( <xref
             href="#topic_vr1_zzk_dx/join-clause" format="dita">join-clause</xref> | <xref
             href="#topic_vr1_zzk_dx/nest-clause" format="dita">nest-clause</xref> | <xref
@@ -145,9 +145,9 @@
         <title>Railroad Diagram: use-keys-clause</title>
         <image placement="break" href="images/use-keys-clause.png" id="image_wpb_vgl_dx"/>
       </fig>
-      <p id="use-index-clause"><codeph>use-index-clause::= USE INDEX “(“ <xref
-            href="#topic_vr1_zzk_dx/index-ref" format="dita">index-ref</xref> [ “,” <xref
-            href="#topic_vr1_zzk_dx/index-ref" format="dita">index-ref</xref> ]* “)”</codeph></p>
+      <p id="use-index-clause"><codeph>use-index-clause::= USE INDEX "(" <xref
+            href="#topic_vr1_zzk_dx/index-ref" format="dita">index-ref</xref> [ "," <xref
+            href="#topic_vr1_zzk_dx/index-ref" format="dita">index-ref</xref> ]* ")"</codeph></p>
       <fig id="fig_h3d_wgl_dx">
         <title>Railroad Diagram: use-index-clause</title>
         <image placement="break" href="images/use-index-clause.png" id="image_i3d_wgl_dx"/>
@@ -171,7 +171,7 @@
       </fig>
     </section>
     <section><title>LET Clause</title>
-      <p id="let-clause"><codeph>let-clause::= LET alias “=” expr [ “,” alias = expr ]*</codeph></p>
+      <p id="let-clause"><codeph>let-clause::= LET alias "=" expr [ "," alias = expr ]*</codeph></p>
       <fig id="fig_sgz_bhl_dx">
         <title>Railroad Diagram: let-clause</title>
         <image placement="break" href="images/let-clause.png" id="image_tgz_bhl_dx"/>
@@ -191,7 +191,7 @@
       </fig>
     </section>   
     <section><title>GROUP BY Clause</title>
-      <p id="group-by-clause"><codeph>group-by-clause::= GROUP BY expr [ “,” expr ]* [ <xref
+      <p id="group-by-clause"><codeph>group-by-clause::= GROUP BY expr [ "," expr ]* [ <xref
             href="#topic_vr1_zzk_dx/letting-clause" format="dita">letting-clause</xref> ] [ <xref
             href="#topic_vr1_zzk_dx/having-clause" format="dita">having-clause</xref> ] | <xref
             href="#topic_vr1_zzk_dx/letting-clause" format="dita">letting-clause</xref></codeph></p>
@@ -199,7 +199,7 @@
         <title>Railroad Diagram: group-by-clause</title>
         <image placement="break" href="images/group-by-clause.png" id="image_cjj_hhl_dx"/>
       </fig>
-      <p id="letting-clause"><codeph>letting-clause::= LETTING alias “=” expr [ “,” alias = expr ]*</codeph></p>
+      <p id="letting-clause"><codeph>letting-clause::= LETTING alias "=" expr [ "," alias = expr ]*</codeph></p>
       <fig id="fig_ym4_3hl_dx">
         <title>Railroad Diagram: letting-clause</title>
         <image placement="break" href="images/letting-clause.png" id="image_zm4_3hl_dx"/>
@@ -218,7 +218,7 @@
     </section>
     <section><title>ORDER BY Clause</title>
       <p id="order-by-clause"><codeph>order-by-clause::= ORDER BY <xref
-            href="#topic_vr1_zzk_dx/ordering-term" format="dita">ordering-term</xref> [ “,” <xref
+            href="#topic_vr1_zzk_dx/ordering-term" format="dita">ordering-term</xref> [ "," <xref
             href="#topic_vr1_zzk_dx/ordering-term" format="dita">ordering-term</xref>
         ]*</codeph></p>
       <fig id="fig_x3n_mhl_dx">

--- a/content/release-notes/relnotes.dita
+++ b/content/release-notes/relnotes.dita
@@ -380,7 +380,7 @@
               <row>
                 <entry><xref href="http://www.couchbase.com/issues/browse/MB-19770" format="html"
                   scope="external">MB-19770</xref></entry>
-                <entry>When the character “!” was used instead of “NOT” in N1QL, incorrect results were produced instead of throwing an error.</entry>
+                <entry>When the character "!" was used instead of "NOT" in N1QL, incorrect results were produced instead of throwing an error.</entry>
               </row>
               <row>
                 <entry><xref href="http://www.couchbase.com/issues/browse/MB-19764" format="html"
@@ -495,7 +495,7 @@
               <row>
                 <entry><xref href="http://www.couchbase.com/issues/browse/MB-19777" format="html"
                   scope="external">MB-19777</xref></entry>
-                <entry>When constructing objects in a N1QL query, the names of fields in name-value pairs is made optional. For example, the following query is valid in 4.5.1 and implicitly assigns names “type” and “name” for respective values: <codeblock>SELECT {type, name} FROM `travel-sample` LIMIT 2;</codeblock></entry>
+                <entry>When constructing objects in a N1QL query, the names of fields in name-value pairs is made optional. For example, the following query is valid in 4.5.1 and implicitly assigns names "type" and "name" for respective values: <codeblock>SELECT {type, name} FROM `travel-sample` LIMIT 2;</codeblock></entry>
               </row>
               <row>
                 <entry><xref href="http://www.couchbase.com/issues/browse/MB-19733" format="html"


### PR DESCRIPTION
This has come up previously - Smart Quotes are bad. They make code blocks invalid, making the end user experience terrible.

This commit is slightly overzealous - it replaces every one, not just those in code blocks. I think this is better though, and perhaps it would be good to add an anti-Smart-Quote commit validation at some point.