### PR TITLE
Update Kafka Connector docs for version 3.2.2

### DIFF
--- a/content/connectors/kafka-3.2/quickstart.dita
+++ b/content/connectors/kafka-3.2/quickstart.dita
@@ -251,6 +251,8 @@ env CLASSPATH=./* \
                     <codeph>true</codeph>. If the connector fails to locate the document ID node, it
                 will fall back to using the Kafka key or <codeph>topic/partition/offset</codeph> as
                 described above.</p>
+            <p>As of version 3.2.2, if the Kafka message body is null, the sink connector will delete
+                the Couchbase document whose ID matches the Kafka message key.</p>
         </section>
 
         <section>

--- a/content/connectors/kafka-3.2/release-notes.dita
+++ b/content/connectors/kafka-3.2/release-notes.dita
@@ -5,6 +5,44 @@
     <shortdesc>Release notes for the Kafka Connector.</shortdesc>
     <conbody>
         <section>
+            <title>Couchbase Kafka Connector 3.2.2 GA (19 December 2017)</title>
+
+            <p>The source connector now does a better job of reporting abnormal termination.
+                Thanks to community member p_mx (tiny1990).</p>
+            <p>A new config key "couchbase.stream_from" lets you tell the source connector
+                when in Couchbase history to start streaming from.
+                Options are "BEGINNING", "NOW", "SAVED_OFFSET_OR_BEGINNING", and "SAVED_OFFSET_OR_NOW".</p>
+            <p>When the sink connector receives a Kafka message with a null value, it now deletes
+                the Couchbase document whose ID matches the Kafka message key. (Previous versions would terminate
+                when a null value was encountered.)</p>
+            <p>You can now specify durability requirements for the sink connector's write operations
+                via two new config keys: "couchbase.durability.persist_to" and "couchbase.durability.replicate_to".</p>
+            <p>Issues resolved in this release:
+            <ul>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-84" format="html" scope="external">KAFKAC-84</xref>:
+                    [FEATURE] Sink: Allow setting durability requirements for Couchbase writes
+                </li>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-85" format="html" scope="external">KAFKAC-85</xref>:
+                    [FEATURE] Sink: Support deletion
+                </li>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-86" format="html" scope="external">KAFKAC-86</xref>:
+                    [FEATURE] Source: Restart from a given state / offset
+                </li>
+            </ul>
+            </p>
+            <p>
+                <codeblock outputclass="language-xml"><![CDATA[<dependency>
+    <groupId>com.couchbase.client</groupId>
+    <artifactId>kafka-connect-couchbase</artifactId>
+    <version>3.2.2</version>
+</dependency>]]></codeblock>
+            </p>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.2.2/kafka-connect-couchbase-3.2.2.zip" format="html" scope="external">kafka-connect-couchbase-3.2.2.zip</xref></p>
+        </section>
+        <section>
             <title>Couchbase Kafka Connector 3.2.1 GA (8 November 2017)</title>
 
             <p>Fixes a regression in 3.2.0 that prevented the sink connector from working.

--- a/content/connectors/kafka-3.2/sink-configuration-options.dita
+++ b/content/connectors/kafka-3.2/sink-configuration-options.dita
@@ -77,6 +77,42 @@ PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
                 <li>Importance: low</li>
                 <li>Default: <codeph>false</codeph></li>
             </ul>
+            <p><codeph>couchbase.durability.persist_to</codeph></p>
+            <p>Optionally specify Couchbase persistence requirements for a write to be
+               considered successful. If the requested requirements cannot be met
+               (due to Couchbase rebalance or failover, for instance) the connector will
+               terminate. Possible values:</p>
+            <ul>
+                <li>NONE - Do not require any disk persistence.</li>
+                <li>MASTER - Require disk persistence to the master node of the document only.</li>
+                <li>ONE - Require disk persistence of one node (master or replica).</li>
+                <li>TWO - Require disk persistence of two nodes (master or replica).</li>
+                <li>THREE - Require disk persistence of three nodes (master or replica).</li>
+                <li>FOUR - Require disk persistence of four nodes (master + three replicas).</li>
+            </ul>
+            <ul>
+                <li>Since: 3.2.2</li>
+                <li>Type: boolean</li>
+                <li>Importance: low</li>
+                <li>Default: <codeph>"NONE"</codeph></li>
+            </ul>
+            <p><codeph>couchbase.durability.replicate_to</codeph></p>
+            <p>Optionally specify Couchbase replication requirements for a write to be
+               considered successful. If the requested requirements cannot be met
+               (due to Couchbase rebalance or failover, for instance) the connector will
+               terminate. Possible values:</p>
+            <ul>
+                <li>NONE - Do not require any replication.</li>
+                <li>ONE - Require replication to one replica.</li>
+                <li>TWO - Require replication to two replicas.</li>
+                <li>THREE - Require replication to three replicas.</li>
+            </ul>
+            <ul>
+                <li>Since: 3.2.2</li>
+                <li>Type: boolean</li>
+                <li>Importance: low</li>
+                <li>Default: <codeph>"NONE"</codeph></li>
+            </ul>
         </section>
     </conbody>
 </concept>

--- a/content/connectors/kafka-3.2/source-configuration-options.dita
+++ b/content/connectors/kafka-3.2/source-configuration-options.dita
@@ -82,7 +82,7 @@ PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
             <ul>
                 <li>Type: string</li>
                 <li>Importance: low</li>
-                <li>Default: <codeph>"com.couchbase.connect.kafka.converter.SchemaConverter"</codeph></li>
+                <li>Default: <codeph>"com.couchbase.connect.kafka.handler.source.DefaultSchemaSourceHandler"</codeph></li>
             </ul>
             <p><codeph>event.filter.class</codeph></p>
             <p>The class name of the event filter to use.</p>
@@ -90,6 +90,20 @@ PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
                 <li>Type: string</li>
                 <li>Importance: low</li>
                 <li>Default: <codeph>"com.couchbase.connect.kafka.filter.AllPassFilter"</codeph></li>
+            </ul>
+            <p><codeph>couchbase.stream_from</codeph></p>
+            <p>The point in Couchbase history to start streaming from. Possible values:</p>
+            <ul>
+                <li>SAVED_OFFSET_OR_BEGINNING - Restart from saved state, or if none, restart from oldest available mutation in Couchbase</li>
+                <li>SAVED_OFFSET_OR_NOW - Restart from saved state, or if none, restart from current Couchbase state</li>
+                <li>BEGINNING - Restart from oldest available mutation in Couchbase (ignore any potential saved state)</li>
+                <li>NOW - Restart from current Couchbase state (ignore any potential saved state)</li>
+            </ul>
+            <ul>
+                <li>Since: 3.2.2</li>
+                <li>Type: string</li>
+                <li>Importance: low</li>
+                <li>Default: <codeph>"SAVED_OFFSET_OR_BEGINNING"</codeph></li>
             </ul>
         </section>
     </conbody>


### PR DESCRIPTION
Kafka Connector 3.2.2 release notes and documentation for new config options.