### PR TITLE
DOC-3097: Remove misleading connection string note

### DIFF
--- a/content/developer-guide/connecting.dita
+++ b/content/developer-guide/connecting.dita
@@ -18,8 +18,7 @@ client = new Bucket(‘couchbase://node://bucket’, ‘bucketPassword’)</code
         <p>The connection string uses a scheme (<codeph>couchbase://</codeph>) followed by the host
             (which is an IP or hostname of any KV cluster node) and a bucket (as the connection
             string’s path). Additional connection options can be specified in a URL-style
-                format.<note>If using multidimensional scaling, it is recommended to specify only
-                data (KV) nodes in the connection string.</note></p>
+	    format.</p>
         <p>See <xref href="connection-advanced.dita#concept_oml_lpm_zs"/> for a detailed overview of
             the connection process, and tips to ensure best performance and application
             behavior.</p>


### PR DESCRIPTION
This page isn't present in newer versions of the docs.