### PR TITLE
Reinstated cbbackupmgr merge docs after 4.6.3

### DIFF
--- a/content/backup-restore/cbbackupmgr-merge.dita
+++ b/content/backup-restore/cbbackupmgr-merge.dita
@@ -3,21 +3,17 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="cbbackupmgr-merge.1">
   <title>cbbackupmgr merge</title>
-  <!-- Replacing help content with note due to MB-20403 -->
-  <body><note type="important"> Due to critical issues, we have temporarily deprecated the merge command in
-        <i>cbbackupmgr</i> from versions 4.5.x and 4.6.x. We plan to fix those and re-introduce
-      support for the command in the upcoming Couchbase Server 4.6.3 and 5.0 releases. <p>We found
-        that a DCP rollback during backup can cause issues later when the merge command was run.
-        Scenarios such as database purging, bucket deletion and recreation, and bucket flush can
-        cause a rollback. To track this issue in JIRA, see <xref
+  <shortdesc>cbbackupmgr-merge - Merges two or more backups together. </shortdesc>
+  <!-- Reinstated help content but with added note due to MB-20403 -->
+  <body><note type="important"> Due to critical issues, we temporarily deprecated the merge command in
+        <i>cbbackupmgr</i> from versions 4.5.x and 4.6.x prior to 4.6.3. We re-introduced
+      support for the command in the Couchbase Server 4.6.3 and 5.0 releases. <p>For more information on this issue, see <xref
           href="https://issues.couchbase.com/browse/MB-20403" format="html" scope="external"
-          >MB-20403</xref></p></note></body>
-  <!--<shortdesc>cbbackupmgr-merge - Merges two or more backups together. </shortdesc>-->
-  <!--<body>
-    <!-\-<section>
+          >MB-20403</xref></p></note>
+    <!--<section>
       <title>Name</title>
       <p>cbbackupmgr-merge - Merges two or more backups together </p>
-    </section>-\->
+    </section>-->
     <section>
       <title>Synopsis</title>
       <p><i>cbbackupmgr merge</i> [-\-archive &lt;archive_dir&gt;] [-\-repo &lt;repo_name&gt;] [-\-start &lt;backup&gt;] [-\-end &lt;backup&gt;] </p>
@@ -105,17 +101,17 @@ Size      Items          Name
         <sli>Directory storing intermediate merge data. 
         </sli></sl>
     </section>
-  <!-\-  <section>
+  <!--  <section>
       <title>See Also</title>
       <p><xref href="cbbackupmgr-list.dita"/>, <xref href="cbbackupmgr-strategies.dita"/> </p>
     </section>
     <section>
       <title>Cbbackupmgr</title>
       <p>Part of the <xref href="cbbackupmgr.dita"/> suite </p>
-    </section>-\->
+    </section>-->
   </body>
   <related-links>
     <link href="cbbackupmgr-list.dita"></link>
     <link href="cbbackupmgr-strategies.dita"></link>
-  </related-links>-->
+  </related-links>
 </topic>


### PR DESCRIPTION
MB-20403 was resolved so docs for this command should be reinstated with note explaining supported versions 4.6.3 and 5.0