### PR TITLE
DOC-3112

### DIFF
--- a/content/backup-restore/cbbackupmgr-merge.dita
+++ b/content/backup-restore/cbbackupmgr-merge.dita
@@ -3,21 +3,17 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="cbbackupmgr-merge.1">
   <title>cbbackupmgr merge</title>
-  <!-- Replacing help content with note due to MB-20403 -->
-  <body><note type="important"> Due to critical issues, we have temporarily deprecated the merge command in
-        <i>cbbackupmgr</i> from versions 4.5.x and 4.6.x. We plan to fix those and re-introduce
-      support for the command in the upcoming Couchbase Server 4.6.3 and 5.0 releases. <p>We found
-        that a DCP rollback during backup can cause issues later when the merge command was run.
-        Scenarios such as database purging, bucket deletion and recreation, and bucket flush can
-        cause a rollback. To track this issue in JIRA, see <xref
+  <shortdesc>cbbackupmgr-merge - Merges two or more backups together. </shortdesc>
+  <!-- Reinstated help content but with added note due to MB-20403 -->
+  <body><note type="important"> Due to critical issues, we temporarily deprecated the merge command in
+        <i>cbbackupmgr</i> from versions 4.5.x and 4.6.x prior to 4.6.3. We re-introduced
+      support for the command in the Couchbase Server 4.6.3 and 5.0 releases. <p>For more information on this issue, see <xref
           href="https://issues.couchbase.com/browse/MB-20403" format="html" scope="external"
-          >MB-20403</xref></p></note></body>
-  <!--<shortdesc>cbbackupmgr-merge - Merges two or more backups together. </shortdesc>-->
-  <!--<body>
-    <!-\-<section>
+          >MB-20403</xref></p></note>
+    <!--<section>
       <title>Name</title>
       <p>cbbackupmgr-merge - Merges two or more backups together </p>
-    </section>-\->
+    </section>-->
     <section>
       <title>Synopsis</title>
       <p><i>cbbackupmgr merge</i> [-\-archive &lt;archive_dir&gt;] [-\-repo &lt;repo_name&gt;] [-\-start &lt;backup&gt;] [-\-end &lt;backup&gt;] </p>
@@ -105,17 +101,17 @@ Size      Items          Name
         <sli>Directory storing intermediate merge data. 
         </sli></sl>
     </section>
-  <!-\-  <section>
+  <!--  <section>
       <title>See Also</title>
       <p><xref href="cbbackupmgr-list.dita"/>, <xref href="cbbackupmgr-strategies.dita"/> </p>
     </section>
     <section>
       <title>Cbbackupmgr</title>
       <p>Part of the <xref href="cbbackupmgr.dita"/> suite </p>
-    </section>-\->
+    </section>-->
   </body>
   <related-links>
     <link href="cbbackupmgr-list.dita"></link>
     <link href="cbbackupmgr-strategies.dita"></link>
-  </related-links>-->
+  </related-links>
 </topic>

--- a/content/backup-restore/cbbackupmgr-merge.dita
+++ b/content/backup-restore/cbbackupmgr-merge.dita
@@ -16,7 +16,7 @@
     </section>-->
     <section>
       <title>Synopsis</title>
-      <p><i>cbbackupmgr merge</i> [-\-archive &lt;archive_dir&gt;] [-\-repo &lt;repo_name&gt;] [-\-start &lt;backup&gt;] [-\-end &lt;backup&gt;] </p>
+      <p><i>cbbackupmgr merge</i> [--archive &lt;archive_dir&gt;] [--repo &lt;repo_name&gt;] [--start &lt;backup&gt;] [--end &lt;backup&gt;] </p>
     </section>
     <section>
       <title>Description</title>
@@ -26,23 +26,23 @@
       <title>Options</title>
       <p>Below are a list of required parameters for the merge command. </p>
       <b>Required</b>
-      <p>-\-archive &lt;archive_dir&gt; </p><sl>
+      <p>--archive &lt;archive_dir&gt; </p><sl>
         <sli>The archive directory to merge data in. 
         </sli></sl>
-      <p>-\-repo &lt;repo_name&gt; </p><sl>
+      <p>--repo &lt;repo_name&gt; </p><sl>
         <sli>The name of the backup repository to merge data in. 
         </sli></sl>
-      <p>-\-start &lt;backup&gt; </p><sl>
+      <p>--start &lt;backup&gt; </p><sl>
         <sli>The name of the first backup to be merged. 
         </sli></sl>
-      <p>-\-end &lt;backup&gt; </p><sl>
+      <p>--end &lt;backup&gt; </p><sl>
         <sli>The name of the last backup to be merged. 
         </sli></sl>
     </section>
     <section>
       <title>Examples</title>
       <p>In order to merge data, you need to have a backup repository with at least two backups. Below is an example of merging a backup repository named "example" that has two backups in it. The first backup contains the initial dataset. The second backup was taken after four items were updated. </p>
-      <codeblock>$ cbbackupmgr list -\-archive /data/backups 
+      <codeblock>$ cbbackupmgr list --archive /data/backups 
  
 Size      Items          Name 
 148.70MB  -              / 
@@ -64,11 +64,11 @@ Size      Items          Name
 4B        0                          gsi.json 
 1.72KB    1                          views.json 
  
-$ cbbackupmgr merge -\-archive /tmp/backup -\-repo example \ 
--\-start 2016-03-01T16_27_10.093782029-08_00 \ 
--\-end 2016-03-01T16_27_51.349151165-08_00 
+$ cbbackupmgr merge --archive /tmp/backup --repo example \ 
+--start 2016-03-01T16_27_10.093782029-08_00 \ 
+--end 2016-03-01T16_27_51.349151165-08_00 
  
-$ cbbackupmgr list -\-archive /tmp/backup 
+$ cbbackupmgr list --archive /tmp/backup 
 Size      Items          Name 
 98.84MB   -              / 
 98.84MB   -              + example 
@@ -84,7 +84,7 @@ Size      Items          Name
     </section>
     <section>
       <title>Discussion</title>
-      <p>It is important that internally the merge command is able to merge backups together without corrupting the backup archive or leaving it in an intermediate state. In order to ensure this behavior <i>cbbackupmgr</i> always creates a new backup and completely merges all data before removing any backup files. When a merge is started a <filepath>.merge_status</filepath> file is created in the backup repository to track the merge progress. <i>cbbackupmgr</i> then copies the first backup to the <filepath>.merge</filepath> folder and begins merging the other backups into <filepath>.merge</filepath> folder. After each backup is merged the <filepath>.merge_status</filepath> file is updated to track the merge progress. If all backups are merged together successfully, <i>cbbackupmgr</i> starts deleting the old backups and then copies the fully merged backup into a folder containing the same name as the backup specified by the <parmname>-\-end</parmname> flag. If the <i>cbbackupmgr</i> utility fails during this process, then the merge is either completed or the partial merge files are removed from the backup repository during the next invocation of the <i>cbbackupmgr</i>. </p>
+      <p>It is important that internally the merge command is able to merge backups together without corrupting the backup archive or leaving it in an intermediate state. In order to ensure this behavior <i>cbbackupmgr</i> always creates a new backup and completely merges all data before removing any backup files. When a merge is started a <filepath>.merge_status</filepath> file is created in the backup repository to track the merge progress. <i>cbbackupmgr</i> then copies the first backup to the <filepath>.merge</filepath> folder and begins merging the other backups into <filepath>.merge</filepath> folder. After each backup is merged the <filepath>.merge_status</filepath> file is updated to track the merge progress. If all backups are merged together successfully, <i>cbbackupmgr</i> starts deleting the old backups and then copies the fully merged backup into a folder containing the same name as the backup specified by the <parmname>--end</parmname> flag. If the <i>cbbackupmgr</i> utility fails during this process, then the merge is either completed or the partial merge files are removed from the backup repository during the next invocation of the <i>cbbackupmgr</i>. </p>
       <p>Since the merge command creates a new backup file before it removes the old ones it is necessary to have at least as much free space as the backups that are to be merge together. </p>
       <p>For more information on suggestions for how to use the merge command in your backup process see <xref href="cbbackupmgr-strategies.dita"/> </p>
     </section>


### PR DESCRIPTION
MB-20403 was resolved so docs for this command should be reinstated with note for supported versions. Fixed the issue with switches having "-\\-" in cbbackupmgr-merge.dita - replaced with "--" from the edited docs