### PR TITLE
Fix incorrect index type

### DIFF
--- a/content/rest-api/rest-fts-indexing.dita
+++ b/content/rest-api/rest-fts-indexing.dita
@@ -26,7 +26,7 @@
              "sourceParams": "",
              "sourceType": "nil",
              "sourceUUID": "",
-             "type": "bleve",
+             "type": "fulltext-index",
              "uuid": "6cc599ab7a85bf3b"
           }
        },
@@ -54,9 +54,10 @@
         },
         "sourceName": "",
         "sourceParams": "",
-        "sourceType": "nil",
+        "source
+            ": "nil",
         "sourceUUID": "",
-        "type": "bleve",
+        "type": "fulltext-index",
         "uuid": "6cc599ab7a85bf3b"
       },
       "planPIndexes": [


### PR DESCRIPTION
type `bleve` returns `unknown indexType: bleve`. The admin interface uses `fulltext-index`