### PR TITLE
Fix 4.6 Query Ports for XDCR

### DIFF
--- a/content/install/install-ports.dita
+++ b/content/install/install-ports.dita
@@ -100,8 +100,8 @@
 						<entry>Yes</entry>
 						<entry>Yes</entry>
 						<entry>No</entry>
-						<entry>Yes</entry>
-						<entry>Yes</entry>
+						<entry>No</entry>
+						<entry>No</entry>
 					</row>
 					<row>
 						<entry>8094**</entry>
@@ -287,8 +287,8 @@
 						<entry>Yes</entry>
 						<entry>Yes</entry>
 						<entry>No</entry>
-						<entry>Yes</entry>
-						<entry>Yes</entry>
+						<entry>No</entry>
+						<entry>No</entry>
 					</row>
 					<row>
 						<entry>18094**</entry>


### PR DESCRIPTION
These ports aren't required for XDCR, as XDCR has no knowledge of the Query Service (e.g. replicating to a cluster with no Query Service at all). @RichardSmedley has further changes in the works, but it would be good to get this quickly fixed now :)