### PR TITLE
Updated cbbackupmgr-archivelayout.dita

### DIFF
--- a/content/backup-restore/cbbackupmgr-archivelayout.dita
+++ b/content/backup-restore/cbbackupmgr-archivelayout.dita
@@ -6,7 +6,7 @@
   <shortdesc>The backup archive is used to store all backup data and this section describes the
     backup archive layout specification. </shortdesc>
   <body>
-    <p> The top level directory of the archive is called the archive backup. The backup archive
+    <p> The top level directory of the archive is called the backup archive. The backup archive
       contains one or more backup repositories and a logs directory. The logs directory contains
       logging information for all cbbackupmgr commands run on the backup archive. Each backup
       repository contains backups for a specific cluster and each backup is done on a cluster


### PR DESCRIPTION
Fixed "archive backup" -> "backup archive"
Rest of text ideally needs revising to be clearer, such as the statement "The top level directory of the archive is called the backup archive" but this fixes word reversal issue.