### PR TITLE
Fixing Typo: missing /

### DIFF
--- a/content/security/security-ldap-tbls-new.dita
+++ b/content/security/security-ldap-tbls-new.dita
@@ -21,7 +21,7 @@
     <dlentry>
      <dt>Errors caused by <codeph>saslauthd</codeph>:</dt>
      <dd><codeblock>.....
-      "dial unix /var/run.sasl2/mux: no such file or directory"</codeblock>
+      "dial unix /var/run/sasl2/mux: no such file or directory"</codeblock>
       <p>Possible reason for the error: no LDAP server was installed.</p>
       <ul>
        <li>Before installing the server again, you can try to resolve the issue by creating a


### PR DESCRIPTION
doc shows: "dial unix /var/run.sasl2/mux: no such file or directory"
instead of: "dial unix /var/run/sasl2/mux: no such file or directory"