### PR TITLE
DOC-2014

### DIFF
--- a/content/security/security-saslauthd-new.dita
+++ b/content/security/security-saslauthd-new.dita
@@ -9,17 +9,15 @@
       server. </p>
     <note type="important">Remote authentication with the LDAP server requires proper configuration
       of the <codeph>saslauthd</codeph> agent, which must be installed and configured on each
-      Couchbase Server node. </note>
-    <note type="note">Make sure that you have the prerequisites for the LDAP software you are installing, 
-      such as OpenLDAP libraries.</note>
-    <note type="note">Installation packages are a part of <codeph>cyrus-sasl rpm</codeph>, so make
-      sure that it is installed.</note>
-    
+      Couchbase Server node.</note>    
     
     <section><title>Supported <codeph>saslauthd</codeph> packages for LDAP
       integration</title>
      
       <p>Install your Unix operating system with the package that is supported for LDAP integration. </p>
+      <p>Make sure that you have the prerequisites for the LDAP software you are installing, 
+        such as OpenLDAP libraries. On RPM-based distros, installation packages are a part of <codeph>cyrus-sasl rpm</codeph>,
+        so make sure that it is installed.</p>
       <dl>
         <dlentry>
           <dt>CentOS 6</dt>
@@ -47,7 +45,6 @@
           <dd><codeph>saslauthd 2.1.23</codeph> or higher</dd>
         </dlentry>
       </dl>
-     
     </section>
     
     <section>
@@ -55,7 +52,7 @@
       </title>
       <p>Make sure your LDAP setup is working by running a test <codeph>ldapsearch</codeph> as follows:</p>
         <p>
-        <codeblock>ldapsearch -LLL -H ldap://ldapserver:389 -D cn=someuser,ou=users,dc=mydomain,dc=com -w Passw0rd -x -bou=users,dc=mydomain,dc=com cn=someuser</codeblock>
+        <codeblock outputclass="language-bash">ldapsearch -LLL -H ldap://ldapserver:389 -D cn=someuser,ou=users,dc=mydomain,dc=com -w Passw0rd -x -bou=users,dc=mydomain,dc=com cn=someuser</codeblock>
       </p>
     </section>
     
@@ -71,100 +68,103 @@
     </section>
     
      <section>
-      <title>Configuring <codeph>saslauthd</codeph> Library for LDAP</title>
-      <p>Depending on the system, the <codeph>saslauthd</codeph> file is configured as follows: </p>
-      <dl>
-        <dlentry>
-          <dt>Red Hat Enterprise Linux, CentOS, and Amazon Linux AMI</dt>
-          <dd>If you are using a system that configures <codeph>saslauthd</codeph> with the file
-              <filepath>/etc/sysconfig/saslauthd</filepath>, such as Red Hat Enterprise Linux,
-            CentOS, and Amazon Linux AMI, set the mechanism <codeph>MECH</codeph> to
-              <codeph>ldap</codeph>: <codeblock>MECH=ldap </codeblock></dd>
-        </dlentry>
-      </dl>
-      <dl>
-        <dlentry>
-          <dt>Ubuntu and Debian</dt>
-          <dd>If you are using a system that configures <codeph>saslauthd</codeph> with the file
-              <filepath>/etc/default/saslauthd</filepath>, such as Ubuntu, set the
-              <codeph>MECHANISMS</codeph> option to <codeph>ldap</codeph>:
-            <codeblock>MECHANISMS=ldap  </codeblock></dd>
-          <dd>On Debian and Ubuntu, you should also add Couchbase to the <codeph>sasl</codeph> group:
-            <codeblock>sudo adduser couchbase sasl</codeblock></dd>
-        </dlentry>
-      </dl>
-       
-    </section>
-       
-       <section><title>Configuring the <codeph>saslauthd</codeph> Configuration File</title>
-         <p>The default configuration file used to obtain the LDAP configuration 
-           parameters is located at <filepath>/usr/local/etc/saslauthd.conf</filepath>.</p>
-       
-       <dl>
-        <dlentry>
-          <dt>Step 1: Set up <codeph>ldap_servers</codeph></dt>
-          <dd>Specify URIs of the LDAP servers used for authentication, such as<codeph>
-              ldap:///10.1.1.11/</codeph>, <codeph>ldap://10.1.1.12/</codeph>. Multiple LDAP servers
-            can be specified in the list, which is then tested to find out whether one of the
-            servers is offline. If you install OpenLDAP on the local host machine, you can specify
-            the value <codeph>ldap://localhost:389</codeph>. If using LDAP over SSL, you can specify
-            the value <codeph>ldaps://localhost:636</codeph>.</dd>
-          <dd>
-            <codeblock>ldap_servers: ldaps://10.1.1.25 ldaps://10.1.1.15</codeblock>
-          </dd>
-        </dlentry>
-      </dl><dl>
-        <dlentry>
-          <dt>Step 2: Set up <codeph>ldap_search_base</codeph></dt>
-          <dd>Specify the distinguished name to which the search is relative. The search includes
-            the base or objects below. </dd>
-          <dd>It also includes Domain Components (<codeph>dc</codeph>) such as in
-              <codeph>dc=company</codeph> and <codeph>dc=com</codeph>. </dd>
-          <dd>The administrative users created in LDAP with the attribute <codeph>uid</codeph> are
+      <title>Getting Started with saslauthd and LDAP</title>
+       <ol>
+         <li><p>Configure the <codeph>MECHANISMS</codeph> option for <codeph>ldap</codeph>.</p>
+           <p><b>Red Hat Enterprise Linux, CentOS, and Amazon Linux AMI</b> edit 
+             <filepath>/etc/sysconfig/saslauthd</filepath> (<codeph>/etc/default/saslauthd</codeph> on Debian/Ubuntu) 
+             to set the mechanism <codeph>MECH</codeph> to
+             <codeph>ldap</codeph>:</p><codeblock>MECH=ldap </codeblock>
+           <p><b>Ubuntu and Debian</b> edit <filepath>/etc/default/saslauthd</filepath>, setting 
+             <codeph>MECHANISMS</codeph> option to <codeph>ldap</codeph>:</p>
+             <codeblock>MECHANISMS=ldap  </codeblock>
+           <p>On Debian and Ubuntu, you should also add Couchbase to the <codeph>sasl</codeph> group:</p>
+            <codeblock outputclass="language-bash">sudo adduser couchbase sasl</codeblock></li>
+         <li><p>The default configuration file used to obtain the LDAP configuration 
+             parameters is located at <filepath>/usr/local/etc/saslauthd.conf</filepath>.
+             Open this in your editor of choice.</p></li>
+         <li><p>Set up <codeph>ldap_servers</codeph></p>
+           <p>Specify URIs of the LDAP servers used for authentication, such as<codeph>
+             ldap:///10.1.1.11/</codeph>, <codeph>ldap://10.1.1.12/</codeph>. Multiple LDAP servers
+             can be specified in the list, which is then tested to find out whether one of the
+             servers is offline. If you install OpenLDAP on the local host machine, you can specify
+             the value <codeph>ldap://localhost:389</codeph>.</p>
+           <p>If using LDAP over SSL, you can specify
+             the value <codeph>ldaps://localhost:636</codeph>.</p>
+             <codeblock>ldap_servers: ldaps://10.1.1.25 ldaps://10.1.1.15</codeblock>
+         </li>
+         <li><p>Set up <codeph>ldap_search_base</codeph></p>
+           <p>Specify the distinguished name to which the search is relative. The search includes
+            the base or objects below. </p>
+          <p>It also includes Domain Components (<codeph>dc</codeph>) such as in
+              <codeph>dc=company</codeph> and <codeph>dc=com</codeph>. </p>
+          <p>The administrative users created in LDAP with the attribute <codeph>uid</codeph> are
             placed under the user's organizational unit <codeph>ou</codeph> under the two domain
-            components (<codeph>example</codeph> and <codeph>com</codeph>).</dd>
-          <dd>
+            components (<codeph>example</codeph> and <codeph>com</codeph>).</p>
+          <p>
             <codeblock>ldap_search_base: ou=Users,dc=company,dc=com</codeblock>
-          </dd>
-        </dlentry>
-      </dl><dl>
-        <dlentry>
-          <dt>Step 3: Set up <codeph>ldap_filter</codeph></dt>
-          <dd>Specify the search filter. The values for these configuration options correspond to
+          </p>
+        </li>
+        <li>
+          <p>Set up <codeph>ldap_filter</codeph></p>
+          <p>Specify the search filter. The values for these configuration options correspond to
             the values specific to the test. For example, to filter on email specify
-              <codeph>ldap_filter: (mail=%n)</codeph>.</dd>
-          <dd>
+              <codeph>ldap_filter: (mail=%n)</codeph>.</p>
+          <p>
             <codeblock>ldap_filter: (uid=%u)</codeblock>
-          </dd>
-          <dd>Configure LDAP options <codeph>/etc/saslauthd.conf</codeph>:
+          </p>
+          <p>Configure LDAP options <codeph>/etc/saslauthd.conf</codeph>:
             <codeblock>ldap_servers: ldaps://ad.example.net
               ldap_search_base: ou=Users,dc=example,dc=com
-              ldap_filter: (uid=%u)</codeblock></dd>
-        </dlentry>
-      </dl>
+              ldap_filter: (uid=%u)</codeblock></p>
+        </li>
+        <li><p>Running automatically</p>
+          <p>For sasld to run automatically on start up, you'll need to change the 
+            <codeph>START</codeph> value to <codeph>YES</codeph>.</p>
+            <codeblock>START = yes</codeblock></li>
+
+        <li><p><b>Test your</b> <codeph>saslauthd</codeph> <b>set-up.</b></p>
+          <p>If the connection is properly working, the user <codeph>couchbase</codeph> must have access to
+            <filepath>/var/run/saslauthd/mux</filepath> (or the appropriate alternate directory for SUSE),
+            in order to communicate to <codeph>saslauthd</codeph>. </p>
+            <ol>
+              <li>Start the saslauthd service (or set it to start automatically with
+                <cmdname>chkconfig</cmdname>).<codeblock outputclass="language-bash">service saslauthd restart
+     Stopping saslauthd:                             [  OK  ]
+     Starting saslauthd:                             [  OK  ]
+            
+chkconfig  saslauthd on
+chkconfig --list saslauthd
+     saslauthd   	0:off   1:off   2:on	3:on	4:on	5:on	6:off</codeblock></li>
+                <li>Test <codeph>saslauthd</codeph> by using the <cmdname>testsaslauth</cmdname> script to
+                  test LDAP authentication:
+                  <codeblock outputclass="language-bash">sudo -u couchbase /usr/sbin/testsaslauthd -u &lt;username&gt; \
+-p mypassword -f /var/run/saslauthd/mux
+<b>0: OK "Success."</b>        </codeblock>
+                </li>
+            </ol>
+        </li>
+       </ol>
     </section>
    
     <section>
       <title>Example </title>
-     
-            <codeblock>$ cat /etc/saslauthd.conf
+          <p>Putting the above steps into typical configuration files:</p>     
+            <codeblock outputclass="language-bash">cat /etc/saslauthd.conf
        # ldap_servers: ldap:&lt;URI&gt;:&lt;PORT&gt; or ldaps:&lt;URI&gt;:&lt;PORT&gt; for TLS protected connection
        ldap_servers: ldap://my.company.com:389
-       # Specifies the distinguished name to which the search is relative. 
-       # The search includes the base # or objects below. It also includes Domain Components (dc) 
-       # such as in dc=company and dc=com.
        # The administrative users created in LDAP with the attribute uid are placed under the user's
        # organizational unit ou under the two domain components (example and com).
        OU=InteractiveUsers,DC=my,DC=company,DC=com
        # Specifies the search filter. The values for these configuration options correspond to the 
        # values specific to the test
-       ldap_filter: (samAccountName=%u)
+       ldap_filter: (uid=%u)
        # Optional: specify a user to perform ldap queries
        ldap_bind_dn: CN=<b>user_ldap</b>,OU=Users,DC=my,DC=company,DC=com
        # Optional: specify ldap user’s password
        ldap_password: -sEcReTp#AssWoRd! </codeblock>
       
-            <codeblock>$ cat /etc/sysconfig/saslauthd
+            <codeblock outputclass="language-bash">cat /etc/sysconfig/saslauthd
        # Just keep the default
        SOCKETDIR=/var/run/saslauthd
        # Make sure MECH is set to ldap (pam is default)
@@ -188,35 +188,22 @@
        ldap_password: secret</codeblock>
    
    </section>
-       
-    <section><title>Test <codeph>saslauthd</codeph></title>
- 
-   <p>If the connection is properly working, the user <codeph>couchbase</codeph> must have access to
-          <filepath>/var/run/saslauthd/mux</filepath> (or the appropriate another folder for SUSE)
-        in order to communicate to <codeph>saslauthd</codeph>. </p>
       
-      <ol>
-        <li>Start the saslauthd service (or set it to start automatically with
-            <cmdname>chkconfig</cmdname>).<codeblock>[root@localhost ~]# service saslauthd restart
-     Stopping saslauthd:                             [  OK  ]
-     Starting saslauthd:                             [  OK  ]
-            
-     [root@localhost ~]# chkconfig  saslauthd on
-     [root@localhost ~]# chkconfig --list saslauthd
-     saslauthd   	0:off   1:off   2:on	3:on	4:on	5:on	6:off</codeblock></li>
-        <li>Test <codeph>saslauthd</codeph> by using the <cmdname>testsaslauth</cmdname> script to
-          test LDAP authentication:
-          <codeblock>[root@localhost ~]# sudo -u couchbase /usr/sbin/testsaslauthd -u &lt;username&gt; \
--p mypassword -f /var/run/saslauthd/mux
-<b>0: OK "Success."</b>        </codeblock>
-        </li>
-        
-      </ol>
-      
- 
- </section>
-      
-      
+    <section id="">
+      <title>Troubleshooting LDAP Settings</title>
+      <shortdesc>What can go wrong with the LDAP setup?</shortdesc>
+        <p>After you set up the LDAP server, <codeph>saslauthd</codeph>, and LDAP administrators, likely
+          causes of problems include:</p>
+        <ul>
+          <li>Firewall ports are not open for LDAP.</li>
+          <li>The Proxy did not start or has started with an inappropriate protocol or hostname.</li>
+          <li>The configuration of saslauthd is incorrect (look at <filepath>/etc/sysconfig/saslauthd</filepath> or
+            <filepath>/etc/saslauthd.conf</filepath>)</li>
+          <li>The LDAP filters are not correct.</li>
+          <li>You can also encounter error messages from the system. These errors belong either to issues
+            caused by <codeph>saslauthd</codeph> or the LDAP server.</li>
+        </ul>
+    </section>
  
   </body>
 </topic>

--- a/content/security/security-saslauthd-new.dita
+++ b/content/security/security-saslauthd-new.dita
@@ -189,7 +189,7 @@ chkconfig --list saslauthd
    
    </section>
       
-    <section id="">
+    <section>
       <title>Troubleshooting LDAP Settings</title>
       <shortdesc>What can go wrong with the LDAP setup?</shortdesc>
         <p>After you set up the LDAP server, <codeph>saslauthd</codeph>, and LDAP administrators, likely

--- a/content/security/security-saslauthd-new.dita
+++ b/content/security/security-saslauthd-new.dita
@@ -115,8 +115,8 @@
           </p>
           <p>Configure LDAP options <codeph>/etc/saslauthd.conf</codeph>:
             <codeblock>ldap_servers: ldaps://ad.example.net
-              ldap_search_base: ou=Users,dc=example,dc=com
-              ldap_filter: (uid=%u)</codeblock></p>
+ldap_search_base: ou=Users,dc=example,dc=com
+ldap_filter: (uid=%u)</codeblock></p>
         </li>
         <li><p>Running automatically</p>
           <p>For sasld to run automatically on start up, you'll need to change the 
@@ -130,12 +130,12 @@
             <ol>
               <li>Start the saslauthd service (or set it to start automatically with
                 <cmdname>chkconfig</cmdname>).<codeblock outputclass="language-bash">service saslauthd restart
-     Stopping saslauthd:                             [  OK  ]
-     Starting saslauthd:                             [  OK  ]
+Stopping saslauthd:                             [  OK  ]
+Starting saslauthd:                             [  OK  ]
             
 chkconfig  saslauthd on
 chkconfig --list saslauthd
-     saslauthd   	0:off   1:off   2:on	3:on	4:on	5:on	6:off</codeblock></li>
+saslauthd   	0:off   1:off   2:on	3:on	4:on	5:on	6:off</codeblock></li>
                 <li>Test <codeph>saslauthd</codeph> by using the <cmdname>testsaslauth</cmdname> script to
                   test LDAP authentication:
                   <codeblock outputclass="language-bash">sudo -u couchbase /usr/sbin/testsaslauthd -u &lt;username&gt; \
@@ -151,26 +151,26 @@ chkconfig --list saslauthd
       <title>Example </title>
           <p>Putting the above steps into typical configuration files:</p>     
             <codeblock outputclass="language-bash">cat /etc/saslauthd.conf
-       # ldap_servers: ldap:&lt;URI&gt;:&lt;PORT&gt; or ldaps:&lt;URI&gt;:&lt;PORT&gt; for TLS protected connection
-       ldap_servers: ldap://my.company.com:389
-       # The administrative users created in LDAP with the attribute uid are placed under the user's
-       # organizational unit ou under the two domain components (example and com).
-       OU=InteractiveUsers,DC=my,DC=company,DC=com
-       # Specifies the search filter. The values for these configuration options correspond to the 
-       # values specific to the test
-       ldap_filter: (uid=%u)
-       # Optional: specify a user to perform ldap queries
-       ldap_bind_dn: CN=<b>user_ldap</b>,OU=Users,DC=my,DC=company,DC=com
-       # Optional: specify ldap user’s password
-       ldap_password: -sEcReTp#AssWoRd! </codeblock>
+# ldap_servers: ldap:&lt;URI&gt;:&lt;PORT&gt; or ldaps:&lt;URI&gt;:&lt;PORT&gt; for TLS protected connection
+ldap_servers: ldap://my.company.com:389
+# The administrative users created in LDAP with the attribute uid are placed under the user's
+# organizational unit ou under the two domain components (example and com).
+OU=InteractiveUsers,DC=my,DC=company,DC=com
+# Specifies the search filter. The values for these configuration options correspond to the 
+# values specific to the test
+ldap_filter: uid=%u
+# Optional: specify a user to perform ldap queries
+ldap_bind_dn: CN=<b>user_ldap</b>,OU=Users,DC=my,DC=company,DC=com
+# Optional: specify ldap user’s password
+ldap_password: -sEcReTp#AssWoRd! </codeblock>
       
             <codeblock outputclass="language-bash">cat /etc/sysconfig/saslauthd
-       # Just keep the default
-       SOCKETDIR=/var/run/saslauthd
-       # Make sure MECH is set to ldap (pam is default)
-       MECH=ldap
-       # Include the config file described above
-       FLAGS="-O /etc/saslauthd.conf"</codeblock>
+# Just keep the default
+SOCKETDIR=/var/run/saslauthd
+# Make sure MECH is set to ldap (pam is default)
+MECH=ldap
+# Include the config file described above
+FLAGS="-O /etc/saslauthd.conf"</codeblock>
     </section>
    
    
@@ -182,10 +182,10 @@ chkconfig --list saslauthd
         (AD):</p>
      
      <codeblock>ldap_servers: ldap://dc1.example.com:&lt;port&gt;
-       ldap_search_base: cn=Users,DC=ad,DC=example,DC=com
-       ldap_filter: sAMAccountName=%u
-       ldap_bind_dn: cn=saslauthd,cn=Users,DC=ad,DC=example,DC=com
-       ldap_password: secret</codeblock>
+ldap_search_base: cn=Users,DC=ad,DC=example,DC=com
+ldap_filter: sAMAccountName=%u
+ldap_bind_dn: cn=saslauthd,cn=Users,DC=ad,DC=example,DC=com
+ldap_password: secret</codeblock>
    
    </section>
       

--- a/content/security/security-saslauthd-new.dita
+++ b/content/security/security-saslauthd-new.dita
@@ -191,7 +191,6 @@ chkconfig --list saslauthd
       
     <section>
       <title>Troubleshooting LDAP Settings</title>
-      <shortdesc>What can go wrong with the LDAP setup?</shortdesc>
         <p>After you set up the LDAP server, <codeph>saslauthd</codeph>, and LDAP administrators, likely
           causes of problems include:</p>
         <ul>


### PR DESCRIPTION
Tidied up the intro, and pruned the outbreak of Notes.
Colorized the Bash examples.
Tidied up config steps into an ordered list, à la PAM page.
Config example - started tidying.
Added the Error section (previously on a separate page).
[All in 5.0 so far - will backport when done]