### PR TITLE
Fix a typo

### DIFF
--- a/content/architecture/connectivity-architecture.dita
+++ b/content/architecture/connectivity-architecture.dita
@@ -7,7 +7,7 @@
   <section id="section-client-2-cluster-comm"><title>Client to Cluster Communication</title> Client
    applications communicate with Couchbase Server through a set of access points tuned for the data
    access category such as CRUD operations, N1QL queries, and so on. Each access point supports
-   clear text and encrypted communication ports. <p> There are four main types of access points that
+   clear text and encrypted communication ports. <p> There are five main types of access points that
     drive the majority of client to server communications. </p><table frame="all" rowsep="1"
     colsep="1" id="table_yph_ppc_ws">
     <title>Communication ports</title>


### PR DESCRIPTION
There are four main types of access points -> There are five main types of access points
(it's confusing that words "there are four main types" are followed by 5-row table)