### PR TITLE
DOC-3087 pre-RBAC SDK

### DIFF
--- a/content/sdk/java/sdk-authentication-overview.dita
+++ b/content/sdk/java/sdk-authentication-overview.dita
@@ -23,6 +23,37 @@
         <section>
             
             <title>
+                Legacy Connection Code
+            </title>
+            
+            <p>
+                These code snippets will enable you to use older, non-RBAC SDK clients with Couchbase Server 5.0 (and beyond).
+              <dl>
+                <dlentry>
+                  <dt>Upgraded Couchbase Server 5.0 with passwordless buckets set up in an older version of Couchabse Server</dt>
+                  <dd>If a cluster with passwordless buckets is upgraded to Couchbase Server 5.0, the corresponding RBAC user entries are generated with username equal to the bucket name and with role set to "Full Bucket Access".
+                      This process enables older SDK versions to access the buckets without creating the "Authentication Object".<br />
+                      The following snippet for a Java SDK with version < 2.4.4 will successfully return the bucket object as there is a user which has the username "beer-sample" (the same as the bucket name).
+<codeblock>Cluster cluster = CouchbaseCluster.create(<hostname>);
+Bucket bucket = cluster.openBucket("beer-sample");</codeblock>
+                  </dt>
+                </dlentry>
+
+                <dlentry>
+                  <dt>Connecting to buckets created in Couchbase Server 5.0 from pre-RBAC SDK Verison</dt>
+                  <dd>To connect to buckets created in Couchbase Server 5.0 itself, using older client versions, you need to manually create a user with username equal the bucket name, and with role set to "Bucket Full Access".
+                      The client can then connect to the bucket using the following sample snippet:
+<codeblock>Cluster cluster = CouchbaseCluster.create(<hostname>);
+Bucket bucket = cluster.openBucket(<bucket-name>, <password for the newly created user>);</codeblock>
+                  </dd>
+                </dlentry>
+              </dl>   
+            </p>
+        </section>
+                    
+        <section>
+            
+            <title>
                 Passing Credentials
             </title>
             

--- a/content/sdk/java/sdk-authentication-overview.dita
+++ b/content/sdk/java/sdk-authentication-overview.dita
@@ -36,7 +36,7 @@
                       The following snippet for a Java SDK with version &lt; 2.4.4 will successfully return the bucket object as there is a user which has the username "beer-sample" (the same as the bucket name).
 <codeblock>Cluster cluster = CouchbaseCluster.create(&lt;hostname>);
 Bucket bucket = cluster.openBucket("beer-sample");</codeblock>
-                  </dt>
+                  </dd>
                 </dlentry>
 
                 <dlentry>

--- a/content/sdk/java/sdk-authentication-overview.dita
+++ b/content/sdk/java/sdk-authentication-overview.dita
@@ -32,7 +32,7 @@
                 <dlentry>
                   <dt>Upgraded Couchbase Server 5.0 with passwordless buckets set up in an older version of Couchabse Server</dt>
                   <dd>If a cluster with passwordless buckets is upgraded to Couchbase Server 5.0, the corresponding RBAC user entries are generated with username equal to the bucket name and with role set to "Full Bucket Access".
-                      This process enables older SDK versions to access the buckets without creating the "Authentication Object".<br />
+                      This process enables older SDK versions to access the buckets without creating the "Authentication Object".
                       The following snippet for a Java SDK with version < 2.4.4 will successfully return the bucket object as there is a user which has the username "beer-sample" (the same as the bucket name).
 <codeblock>Cluster cluster = CouchbaseCluster.create(<hostname>);
 Bucket bucket = cluster.openBucket("beer-sample");</codeblock>

--- a/content/sdk/java/sdk-authentication-overview.dita
+++ b/content/sdk/java/sdk-authentication-overview.dita
@@ -33,7 +33,7 @@
                   <dt>Upgraded Couchbase Server 5.0 with passwordless buckets set up in an older version of Couchabse Server</dt>
                   <dd>If a cluster with passwordless buckets is upgraded to Couchbase Server 5.0, the corresponding RBAC user entries are generated with username equal to the bucket name and with role set to "Full Bucket Access".
                       This process enables older SDK versions to access the buckets without creating the "Authentication Object".
-                      The following snippet for a Java SDK with version < 2.4.4 will successfully return the bucket object as there is a user which has the username "beer-sample" (the same as the bucket name).
+                      The following snippet for a Java SDK with version &lt; 2.4.4 will successfully return the bucket object as there is a user which has the username "beer-sample" (the same as the bucket name).
 <codeblock>Cluster cluster = CouchbaseCluster.create(<hostname>);
 Bucket bucket = cluster.openBucket("beer-sample");</codeblock>
                   </dt>

--- a/content/sdk/java/sdk-authentication-overview.dita
+++ b/content/sdk/java/sdk-authentication-overview.dita
@@ -34,7 +34,7 @@
                   <dd>If a cluster with passwordless buckets is upgraded to Couchbase Server 5.0, the corresponding RBAC user entries are generated with username equal to the bucket name and with role set to "Full Bucket Access".
                       This process enables older SDK versions to access the buckets without creating the "Authentication Object".
                       The following snippet for a Java SDK with version &lt; 2.4.4 will successfully return the bucket object as there is a user which has the username "beer-sample" (the same as the bucket name).
-<codeblock>Cluster cluster = CouchbaseCluster.create(<hostname>);
+<codeblock>Cluster cluster = CouchbaseCluster.create(&lt;hostname>);
 Bucket bucket = cluster.openBucket("beer-sample");</codeblock>
                   </dt>
                 </dlentry>
@@ -43,8 +43,8 @@ Bucket bucket = cluster.openBucket("beer-sample");</codeblock>
                   <dt>Connecting to buckets created in Couchbase Server 5.0 from pre-RBAC SDK Verison</dt>
                   <dd>To connect to buckets created in Couchbase Server 5.0 itself, using older client versions, you need to manually create a user with username equal the bucket name, and with role set to "Bucket Full Access".
                       The client can then connect to the bucket using the following sample snippet:
-<codeblock>Cluster cluster = CouchbaseCluster.create(<hostname>);
-Bucket bucket = cluster.openBucket(<bucket-name>, <password for the newly created user>);</codeblock>
+<codeblock>Cluster cluster = CouchbaseCluster.create(&lt;hostname>);
+Bucket bucket = cluster.openBucket(&lt;bucket-name>, &lt;password for the newly created user>);</codeblock>
                   </dd>
                 </dlentry>
               </dl>   

--- a/content/sdk/java/sdk-authentication-overview.dita
+++ b/content/sdk/java/sdk-authentication-overview.dita
@@ -30,7 +30,7 @@
                 These code snippets will enable you to use older, non-RBAC SDK clients with Couchbase Server 5.0 (and beyond).
               <dl>
                 <dlentry>
-                  <dt>Upgraded Couchbase Server 5.0 with passwordless buckets set up in an older version of Couchabse Server</dt>
+                  <dt>Upgraded Couchbase Server 5.0 with passwordless buckets set up in an older version of Couchabse Server:</dt>
                   <dd>If a cluster with passwordless buckets is upgraded to Couchbase Server 5.0, the corresponding RBAC user entries are generated with username equal to the bucket name and with role set to "Full Bucket Access".
                       This process enables older SDK versions to access the buckets without creating the "Authentication Object".
                       The following snippet for a Java SDK with version &lt; 2.4.4 will successfully return the bucket object as there is a user which has the username "beer-sample" (the same as the bucket name).
@@ -40,7 +40,7 @@ Bucket bucket = cluster.openBucket("beer-sample");</codeblock>
                 </dlentry>
 
                 <dlentry>
-                  <dt>Connecting to buckets created in Couchbase Server 5.0 from pre-RBAC SDK Verison</dt>
+                  <dt>Connecting to buckets created in Couchbase Server 5.0 from pre-RBAC SDK Verison:</dt>
                   <dd>To connect to buckets created in Couchbase Server 5.0 itself, using older client versions, you need to manually create a user with username equal the bucket name, and with role set to "Bucket Full Access".
                       The client can then connect to the bucket using the following sample snippet:
 <codeblock>Cluster cluster = CouchbaseCluster.create(&lt;hostname>);


### PR DESCRIPTION
For the older client SDK versions which do not have inbuilt support for RBAC, connecting to Couchbase Server 5.