### PR TITLE
DOC-2747

### DIFF
--- a/content/rest-api/rest-api.ditamap
+++ b/content/rest-api/rest-api.ditamap
@@ -84,7 +84,6 @@
 				<topicref href="rest-xdcr-statistics.dita"/>
 			</topicref>
 			<topicref href="compaction-rest-api.dita" collection-type="sequence">
-				<topicref href="security-encrypted-access.dita"/>
 				<topicref href="rest-compact-post.dita"/>
 				<topicref href="rest-compact-spatialviews.dita"/>
 				<topicref href="rest-autocompact-get.dita"/>
@@ -106,6 +105,7 @@
 					<topicref href="rest-user-delete.dita"/>
 				</topicref>
 
+				<topicref href="security-encrypted-access.dita"/>
 				<topicref href="rest-encryption.dita"/>
 				<topicref href="rest-secret-mgmt.dita"/>
 


### PR DESCRIPTION
Moved "Using REST for Encrypted Access" under Authorization API.