### PR TITLE
Indicate that changing 'default' bucket's authentication is not allowed

### DIFF
--- a/content/rest-api/rest-bucket-auth.dita
+++ b/content/rest-api/rest-bucket-auth.dita
@@ -9,11 +9,11 @@
 
     <section><title>Description</title>
       <p>Changing a bucket from port-based authentication to SASL authentication is achieved by
-        changing the active bucket configuration. </p>
-      <note type="important">When changing the active bucket configuration, specify the existing
-        configuration parameters and the changed authentication parameters.</note>
-      <note type="important">Changing the pre stablished authentication for bucket <codeph>default</codeph>
-        is not allowed; any attempt to change it will be ignored.</note>
+        changing the active bucket configuration. When changing the active bucket configuration, specify the existing
+        configuration parameters, <i>and</i> the changed authentication parameters.</p>
+      <note type="note">The <codeph>default</codeph> bucket cannot have authentication
+        added &#8212; any attempt to change it will be ignored &#8212; this is why it is recommended to
+        remove it from production machines.</note>
     </section>
     
     <section><title>HTTP method and URI</title>


### PR DESCRIPTION
While trying to set a password for the default bucket I realised it is not possible to change it and I thought it's worthwhile to be mentioned in the docs.