### PR TITLE
Update Kafka Connector docs for version 3.2.3

### DIFF
--- a/content/connectors/kafka-3.2/quickstart.dita
+++ b/content/connectors/kafka-3.2/quickstart.dita
@@ -7,8 +7,8 @@
         <section>
             <title>Download</title>
             <p>The connector is shipped as a zip archive, available for download:
-            <xref href="https://packages.couchbase.com/clients/kafka/3.2.1/kafka-connect-couchbase-3.2.1.zip"
-                    format="html" scope="external">kafka-connect-couchbase-3.2.1.zip</xref></p>
+            <xref href="https://packages.couchbase.com/clients/kafka/3.2.3/kafka-connect-couchbase-3.2.3.zip"
+                    format="html" scope="external">kafka-connect-couchbase-3.2.3.zip</xref></p>
             <p>If you prefer to build the connectors from source, clone the
             <xref href="https://github.com/couchbase/kafka-connect-couchbase" format="html" scope="external">GitHub repository</xref>
             and run <codeph>mvn package</codeph> to generate the connector archive
@@ -80,7 +80,7 @@ kafka-server-start.sh $KAFKA_HOME/config/server.properties</codeblock>
                         <codeph>travel-sample</codeph> (or whichever bucket you want to stream
                     from). For <codeph>connection.username</codeph> and
                         <codeph>connection.password</codeph>, supply the credentials of a Couchbase
-                    user with read access to the bucket. If you have not yet created such a user,
+                    user who has the "Data DCP Reader" role for the bucket. If you have not yet created such a user,
                     now is a good time to read about
                     <xref href="../../security/security-rbac-for-admins-and-apps.dita" scope="local" format="dita">
                         Creating and Managing Users with the UI</xref>.</p>

--- a/content/connectors/kafka-3.2/release-notes.dita
+++ b/content/connectors/kafka-3.2/release-notes.dita
@@ -5,6 +5,42 @@
     <shortdesc>Release notes for the Kafka Connector.</shortdesc>
     <conbody>
         <section>
+            <title>Couchbase Kafka Connector 3.2.3 GA (2018-02-20)</title>
+
+            <p>Keepalive is now enabled on the Couchbase Server connection. This prevents the server from dropping
+            idle connections, and enables dead connection detection. Thanks to community member Patrik Nordebo (patrikn).</p>
+            <p>A new config key "couchbase.log_redaction" controls
+                whether sensitive info in connector log messages is tagged for redaction.
+                Options are "NONE", "PARTIAL", and "FULL".</p>
+            <p>A new source config key "couchbase.compression" can be used to enable
+               compression when reading from Couchbase Server 4.5 and later.
+               Options are "DISABLED", "ENABLED", and "FORCED".</p>
+            <p>Issues resolved in this release:
+            <ul>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-89" format="html" scope="external">KAFKAC-89</xref>:
+                    [ENHANCEMENT] Enable NOOP for dead connection detection (Patrik Nordebo)
+                </li>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-82" format="html" scope="external">KAFKAC-82</xref>:
+                    [FEATURE] Implement log redaction for Kafka Connector
+                </li>
+                <li>
+                    <xref href="https://issues.couchbase.com/browse/KAFKAC-90" format="html" scope="external">KAFKAC-90</xref>:
+                    [FEATURE] Source: Add config settings to enable compression
+                </li>
+            </ul>
+            </p>
+            <p>
+                <codeblock outputclass="language-xml"><![CDATA[<dependency>
+    <groupId>com.couchbase.client</groupId>
+    <artifactId>kafka-connect-couchbase</artifactId>
+    <version>3.2.3</version>
+</dependency>]]></codeblock>
+            </p>
+            <p><xref href="http://packages.couchbase.com/clients/kafka/3.2.3/kafka-connect-couchbase-3.2.3.zip" format="html" scope="external">kafka-connect-couchbase-3.2.3.zip</xref></p>
+        </section>
+        <section>
             <title>Couchbase Kafka Connector 3.2.2 GA (19 December 2017)</title>
 
             <p>The source connector now does a better job of reporting abnormal termination.

--- a/content/connectors/kafka-3.2/sink-configuration-options.dita
+++ b/content/connectors/kafka-3.2/sink-configuration-options.dita
@@ -113,6 +113,19 @@ PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
                 <li>Importance: low</li>
                 <li>Default: <codeph>"NONE"</codeph></li>
             </ul>
+            <p><codeph>couchbase.log_redaction</codeph></p>
+            <p>Optionally tag sensitive values in the log output for later redaction. Possible values:</p>
+            <ul>
+                <li>NONE - No redaction is performed.</li>
+                <li>PARTIAL - Only user data is redacted, system and metadata are not.</li>
+                <li>FULL - User, System and Metadata are all redacted.</li>
+            </ul>
+            <ul>
+                <li>Since: 3.2.3</li>
+                <li>Type: string</li>
+                <li>Importance: low</li>
+                <li>Default: <codeph>"NONE"</codeph></li>
+            </ul>
         </section>
     </conbody>
 </concept>

--- a/content/connectors/kafka-3.2/source-configuration-options.dita
+++ b/content/connectors/kafka-3.2/source-configuration-options.dita
@@ -105,6 +105,36 @@ PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
                 <li>Importance: low</li>
                 <li>Default: <codeph>"SAVED_OFFSET_OR_BEGINNING"</codeph></li>
             </ul>
+            <p><codeph>couchbase.log_redaction</codeph></p>
+            <p>Optionally tag sensitive values in the log output for later redaction. Possible values:</p>
+            <ul>
+                <li>NONE - No redaction is performed.</li>
+                <li>PARTIAL - Only user data is redacted, system and metadata are not.</li>
+                <li>FULL - User, System and Metadata are all redacted.</li>
+            </ul>
+            <ul>
+                <li>Since: 3.2.3</li>
+                <li>Type: string</li>
+                <li>Importance: low</li>
+                <li>Default: <codeph>"NONE"</codeph></li>
+            </ul>
+            <p><codeph>couchbase.compression</codeph></p>
+            <p>To reduce bandwidth usage, Couchbase Server 4.5 and later can send documents to the connector in compressed form.
+               (Messages are always published to the Kafka topic in uncompressed form, regardless of this setting.)
+               Possible values:</p>
+            <ul>
+                <li>DISABLED - No compression.</li>
+                <li>ENABLED - Couchbase Server decides whether to use compression on a per-document basis. For Couchbase 5.5 and later,
+                              the document will be sent compressed if the server already has easy access to the compressed form.
+                              For older server versions, this mode is equivalent to FORCED, and may increase server CPU load.</li>
+                <li>FORCED - Compression is used for every document, unless compressed size is greater than uncompressed size.</li>
+            </ul>
+            <ul>
+                <li>Since: 3.2.3</li>
+                <li>Type: string</li>
+                <li>Importance: low</li>
+                <li>Default: <codeph>"DISABLED"</codeph></li>
+            </ul>
         </section>
     </conbody>
 </concept>


### PR DESCRIPTION
* Release notes for Kafka connector 3.2.3.

* Documentation updates for new config keys.

* Correct a mistake in the quickstart guide. The user needs "Data DCP Reader",
not general read access.