### PR TITLE
DOC-1549

### DIFF
--- a/content/sdk/java/compatibility-versions-features.dita
+++ b/content/sdk/java/compatibility-versions-features.dita
@@ -13,7 +13,7 @@
                     <li> ✖ <b>Unsupported</b>: This combination is not tested, and is not within the scope of
                         technical support if you have purchased a support agreement. </li>
                     <li> ◎ <b>Compatible</b>: This combination has been tested previously, and should be
-                        compatible. This combination is not supported or recommended by our technical support
+                        compatible. This combination is not recommended by our technical support
                         organization. It is best to upgrade either the SDK or the Couchbase version you are
                         using. </li>
                     <li> ✔ <b>Supported</b>:This combination is subject to ongoing quality assurance, and is
@@ -27,13 +27,9 @@
                     <colspec colname="c3" colnum="3" colwidth="1*"/>
                     <colspec colname="c4" colnum="4" colwidth="1*"/>
                     <colspec colname="c5" colnum="5" colwidth="1*"/>
-                    <colspec colname="c6" colnum="6" colwidth="1*"/>
-                    <colspec colname="c7" colnum="7" colwidth="1*"/>
                     <thead>
                         <row>
                             <entry/>
-                            <entry><i>Under 1.4</i></entry>
-                            <entry><i>SDK 1.4</i></entry>
                             <entry><i>SDK 2.0, 2.1</i></entry>
                             <entry><b>SDK 2.2, 2.3</b></entry>
                             <entry><b>SDK 2.4</b></entry>
@@ -44,69 +40,34 @@
                         <row>
                             <entry><i>SDK released for ></i></entry>
                             <entry><i>N/A (Archived)</i></entry>
-                            <entry><i>Bug fixes only</i></entry>
-                            <entry><i>N/A (Archived)</i></entry>
                             <entry><i>Bug fixes and minor features Back ports</i></entry>
                             <entry><i>New Features, Active Development</i></entry>
                             <entry><i>New Features, Active Development</i></entry>
                         </row>
                         <row>
-                            <entry><b>Server 1.8</b></entry>
-                            <entry>◎</entry><entry>◎</entry><entry>◎</entry>
-                            <entry>◎</entry> <entry><b>◎</b></entry>
-                            <entry><b>◎</b></entry>
-                        </row>
-                        <row>
-                            <entry><b>Server 2.0</b></entry>
-                            <entry>◎</entry><entry>◎</entry><entry>◎</entry>
-                            <entry>◎</entry> <entry><b>◎</b></entry>
-                            <entry><b>◎</b></entry>
-                        </row>
-                        <row>
-                            <entry><b>Server 2.5</b></entry>
-                            <entry>◎</entry><entry>◎</entry><entry>◎</entry>
-                            <entry>◎</entry> <entry><b>◎</b></entry>
-                            <entry><b>◎</b></entry>
-                        </row>
-                        <row>
-                            <entry><b>Server 3.0</b></entry>
-                            <entry>◎</entry><entry>◎</entry><entry>◎</entry>
+                            <entry><b>Server 3.1</b></entry>
+                            <entry>◎</entry>
                             <entry>✔</entry> <entry><b>✔</b></entry>
                             <entry><b>✔</b></entry>
                         </row>
                         <row>
-                            <entry><b>Server 4.0</b></entry>
-                            <entry>◎</entry><entry>◎</entry><entry>◎</entry>
-                            <entry>✔</entry> <entry><b>✔</b></entry>
-                            <entry><b>✔</b></entry>
-                        </row>
-                        <row>
-                            <entry><b>Server 4.1</b></entry>
-                            <entry>◎</entry><entry>◎</entry><entry>◎</entry>
-                            <entry>✔</entry> <entry><b>✔</b></entry>
-                            <entry><b>✔</b></entry>
-                        </row>
-                        <row>
-                            <entry><b>Server 4.5</b></entry>
-                            <entry>◎</entry><entry>◎</entry><entry>◎</entry>
-                            <entry>✔</entry> <entry><b>✔</b></entry>
-                            <entry><b>✔</b></entry>
-                        </row>
-                        <row>
-                            <entry><b>Server 4.6</b></entry>
-                            <entry>◎</entry><entry>◎</entry><entry>◎</entry>
+                            <entry><b>Server 4.0-4.6</b></entry>
+                            <entry>◎</entry>
                             <entry>✔</entry> <entry><b>✔</b></entry>
                             <entry><b>✔</b></entry>
                         </row>
                         <row>
                             <entry><b>Server 5.0</b></entry>
-                            <entry>◎</entry><entry>◎</entry><entry>◎</entry>
+                            <entry>◎</entry>
                             <entry>◎</entry> <entry><b>✔</b></entry>
                             <entry><b>✔</b></entry>
                         </row>
                     </tbody>
                 </tgroup>
             </table>
+            <p>Note the <xref href="https://www.couchbase.com/support-policy" scope="external" format="html">
+                End of Life dates</xref> for Couchbase Server and SDK versions. 
+                See the notes there for Support details.</p>
 
             <p>To take advantage of all features offered by Couchbase Server, you need to know what
                 version of the Java SDK provides compatibility for the features you want to use. The


### PR DESCRIPTION
Fixed the table by pruning off old server versions (1.8, 2.0, 3.0) and SDK versions (<2.0).
Added note on end-of-life with link to Support page.
Ammended text to "not recommended", as requested.