### PR TITLE
remove duplicate on couchbase-cli cluster-init

### DIFF
--- a/content/cli/cbcli/couchbase-cli-cluster-init.dita
+++ b/content/cli/cbcli/couchbase-cli-cluster-init.dita
@@ -243,10 +243,6 @@ changed after a cluster is initialized. Use the
         variable allows you to specify a default argument for the -p/--password
         argument on the command line. It also allows the user to ensure that their
         password are not cached in their command line history.</p>
-        <p outputclass="db.simpara">CB_REST_PASSWORD
-        Specifies the password of the user executing the command. This environment
-        variable allows you to specify a default argument for the -p/--password
-        argument on the command line.</p>
       </section></body>
     <related-links><link href="couchbase-cli-cluster-edit.dita" /><link href="couchbase-cli-node-init.dita" /><link href="couchbase-cli-server-add.dita" /></related-links></topic>
 </dita>


### PR DESCRIPTION
Hi,

CB_REST_PASSWORD is documented twice, i've removed the less complete one

Thanks,