### PR TITLE
DOC-3252

### DIFF
--- a/content/sdk/go/managing-connections.dita
+++ b/content/sdk/go/managing-connections.dita
@@ -27,7 +27,7 @@
                 - which should be provided if the bucket is password protected, or supplied as
                     <codeph>nil</codeph> otherwise.</p>
             <codeblock outputclass="language-go">bucket1, err := cluster.OpenBucket("messages", nil)
-protectedBucket, err := cluster.openBucket("protected", "s3cr3t")</codeblock>
+protectedBucket, err := cluster.OpenBucket("protected", "s3cr3t")</codeblock>
             <p>Note that the bucket password is <i>not</i> the administrative password used to
                 access the Couchbase Web UI.</p>
             <p>Once the bucket has been created, it may be used throughout your application. Buckets


### PR DESCRIPTION
Upper Case issue:
`protectedBucket, err := cluster.openBucket("protected", "s3cr3t”)`
open should be Open