### PR TITLE
DOC-3057

### DIFF
--- a/content/sdk/php/sdk-authentication-overview.dita
+++ b/content/sdk/php/sdk-authentication-overview.dita
@@ -128,8 +128,8 @@
                 the <xref href="../c/sdk-authentication-overview.dita" scope="local" format="dita">C SDK Authentication page</xref>.</p>
             
             <p>
-                You will need to load the php_openssl module before php_couchbase in your code. If you are using a self-signed
-                Cluster certificate, instead of a fresh one, fetch it with:<codeblock> * $ curl http://localhost:8091/pools/default/certificate > /tmp/couchbase-ssl-certificate.pem</codeblock></p>
+                You will need to load the <codeph>php_openssl</codeph> module before <codeph>php_couchbase</codeph> in your code. If you are using a self-signed
+                Cluster certificate, instead of a fresh one, fetch it with:<codeblock>curl http://localhost:8091/pools/default/certificate > /tmp/couchbase-ssl-certificate.pem</codeblock></p>
             <p>
                 You can now connect with the following in your <codeph>&lt;php</codeph> 
                 block:<codeblock>$cluster = new \Couchbase\Cluster('couchbases://localhost?certpath=/tmp/couchbase-ssl-certificate.pem');

--- a/content/sdk/php/sdk-authentication-overview.dita
+++ b/content/sdk/php/sdk-authentication-overview.dita
@@ -101,6 +101,41 @@
             </ul>
         </section>
         
+        <section>
+            <title>
+                Certificate-Based Authentication
+            </title>
+            
+            <p>
+                Couchbase Server supports the use of X.509 certificates to authenticate clients. This allows
+                authenticated users to access specific resources by means of the data service (no other service
+                is currently available to clients through this form of authentication). 
+            </p>
+            
+            <p>    
+                The process relies on a certificate
+                authority, for the issuing of certificates that validate identities. A certificate includes
+                information such as the name of the entity it identifies, an expiration date, the name of the authority
+                that issued the certificate, and the digital signature of the authority.
+                A client attempting to access Couchbase Server can present a certificate to the server, allowing
+                the server to check the validity of the certificate. If the certificate is valid, the user
+                under whose identity the client is running,
+                and the roles assigned that user, are verified. If the assigned roles are appropriate for
+                the level of access requested to the specified resource, access is granted.
+            </p>
+            
+            <p>The PHP SDK has supported certificate authentication since version 2.4.3. The client certificate can be generated with the shell script on 
+                the <xref href="../c/sdk-authentication-overview.dita" scope="local" format="dita">C SDK Authentication page</xref>.</p>
+            
+            <p>
+                You will need to load the php_openssl module before php_couchbase in your code. If you are using a self-signed
+                Cluster certificate, instead of a fresh one, fetch it with:<codeblock> * $ curl http://localhost:8091/pools/default/certificate > /tmp/couchbase-ssl-certificate.pem</codeblock></p>
+            <p>
+                You can now connect with the following in your <codeph>&lt;php</codeph> 
+                block:<codeblock>$cluster = new \Couchbase\Cluster('couchbases://localhost?certpath=/tmp/couchbase-ssl-certificate.pem');
+$bucket = $cluster->openBucket('default');</codeblock></p>
+        </section>
+  
     </body>
         
 </topic>

--- a/content/sdk/php/sdk-authentication-overview.dita
+++ b/content/sdk/php/sdk-authentication-overview.dita
@@ -125,14 +125,11 @@
             </p>
             
             <p>The PHP SDK has supported certificate authentication since version 2.4.3. The client certificate can be generated with the shell script on 
-                the <xref href="../c/sdk-authentication-overview.dita" scope="local" format="dita">C SDK Authentication page</xref>.</p>
-            
-            <p>
-                You will need to load the <codeph>php_openssl</codeph> module before <codeph>php_couchbase</codeph> in your code. If you are using a self-signed
-                Cluster certificate, instead of a fresh one, fetch it with:<codeblock>curl http://localhost:8091/pools/default/certificate > /tmp/couchbase-ssl-certificate.pem</codeblock></p>
+                the <xref href="../c/sdk-authentication-overview.dita" scope="local" format="dita">C SDK Authentication page</xref>. Note 
+                that you will need to load the <codeph>php_openssl</codeph> module before <codeph>php_couchbase</codeph> in your code.</p>
             <p>
                 You can now connect with the following in your <codeph>&lt;php</codeph> 
-                block:<codeblock>$cluster = new \Couchbase\Cluster('couchbases://localhost?certpath=/tmp/couchbase-ssl-certificate.pem');
+                block:<codeblock>$cluster = new \Couchbase\Cluster('couchbases://localhost?certpath=/path/to/chain.pem&amp;keypath=/path/to/client.key');
 $bucket = $cluster->openBucket('default');</codeblock></p>
         </section>
   


### PR DESCRIPTION
x.509 certificate based authentication for SDKs.
In 5.1, the plan is to introduce X.509 Certificate Authentication support in all Client SDKs (.NET, Node.js, Python, and other SDKs).