### PR TITLE
DOC-3057

### DIFF
--- a/content/sdk/go/sdk-authentication-overview.dita
+++ b/content/sdk/go/sdk-authentication-overview.dita
@@ -100,6 +100,37 @@
                 </li>
             </ul>
         </section>
+
+        
+        <section>
+            <title>
+                Certificate-Based Authentication
+            </title>
+            
+            <p>
+                Couchbase Server supports the use of X.509 certificates to authenticate clients. This allows
+                authenticated users to access specific resources by means of the data service (no other service
+                is currently available to clients through this form of authentication). 
+            </p>
+            
+            <p>    
+                The process relies on a certificate
+                authority, for the issuing of certificates that validate identities. A certificate includes
+                information such as the name of the entity it identifies, an expiration date, the name of the authority
+                that issued the certificate, and the digital signature of the authority.
+                A client attempting to access Couchbase Server can present a certificate to the server, allowing
+                the server to check the validity of the certificate. If the certificate is valid, the user
+                under whose identity the client is running,
+                and the roles assigned that user, are verified. If the assigned roles are appropriate for
+                the level of access requested to the specified resource, access is granted.
+            </p>
+            
+            <p>The Go SDK has supported certificate authentication since version 1.3.3. The client certificate can be generated with the shell script on 
+                the <xref href="../c/sdk-authentication-overview.dita" scope="local" format="dita">C SDK Authentication page</xref>. 
+                Connection involves using <codeph>gocb.CertificateAuthenticator{}</codeph> to tell the Server that cert-auth is the 
+                authenticator, and passing <codeph>cert_path</codeph> and <codeph>key_path</codeph> in the connection string:<codeblock>gocb.CertificateAuthenticator{}
+cluster, err := gocb.Connect("couchbases://10.0.0.1?certpath=/path/to/chain.pem&amp;keypath=/path/to/client.key");</codeblock></p>
+        </section>
         
     </body>
         


### PR DESCRIPTION
x.509 certificate based authentication for SDKs.
In 5.1, the plan is to introduce X.509 Certificate Authentication support in all Client SDKs (.NET, Node.js, Python, and other SDKs).