### PR TITLE
doc: fix: warning is not a valid logging level

### DIFF
--- a/content/clustersetup/ui-logs.dita
+++ b/content/clustersetup/ui-logs.dita
@@ -281,7 +281,7 @@
                 <codeph>cluster</codeph>, views, <codeph>mapreduce_errors</codeph> , xdcr and
                 <codeph>error_logger</codeph>.</li>
             <li><codeph>logging_level</codeph> - The available log levels are
-              <codeph>debug</codeph>, <codeph>info</codeph>, <codeph>warning</codeph>, and
+              <codeph>debug</codeph>, <codeph>info</codeph>, <codeph>warn</codeph>, and
                 <codeph>error</codeph>.<codeblock>curl -X POST -u Administrator:password http://127.0.0.1:8091/diag/eval \ 
                 -d 'ale:set_loglevel(ns_server,error).				</codeblock></li>
           </ul></p></sectiondiv>


### PR DESCRIPTION
The right level is "warn"