### PR TITLE
Corrected code snippet formatting per DOC-2722 (4.6)

### DIFF
--- a/content/fts/fts-queries.dita
+++ b/content/fts/fts-queries.dita
@@ -184,28 +184,28 @@ http://127.0.0.1:8094/api/index/beer-idx/query \
                 specify size "<userinput>0</userinput>" to return no results, as in the following
                 example:
                 <codeblock>curl -X POST -H "Content-Type: application/json" \
-                  http://127.0.0.1:8094/api/index/beer-idx/query \
-                  -d '{
-                  "indexName": "beer-idx",
-                  "size": 0,
-                  "from": 0,
-                  "explain": true,
-                  "highlight": {},
-                  "query": {
-                  "boost": 1,
-                  "query": "geo.accuracy:rooftop"
-                  },
-                  "fields": [
-                  "*"
-                  ],
-                  "ctl": {
-                  "consistency": {
-                  "level": "",
-                  "vectors": {}
-                  },
-                  "timeout": 0
-                  }
-                  }'</codeblock></p>
+http://127.0.0.1:8094/api/index/beer-idx/query -d \
+'{
+    "indexName": "beer-idx",
+    "size": 0,
+    "from": 0,
+    "explain": true,
+    "highlight": {},
+    "query": {
+        "boost": 1,
+        "query": "geo.accuracy:rooftop"
+    },
+    "fields": [
+        "*"
+    ],
+    "ctl": {
+        "consistency": {
+            "level": "",
+            "vectors": {}
+        },
+        "timeout": 0
+    }
+}'</codeblock></p>
           <p>You can get a count of entries in an index overall by using the REST API:
                 <codeblock>http://localhost:8094/api/index/beer-idx/count</codeblock></p>
       </section>

--- a/content/fts/fts-queries.dita
+++ b/content/fts/fts-queries.dita
@@ -240,89 +240,89 @@ http://127.0.0.1:8094/api/index/beer-idx/query \
                   <li>Term Facet - computes facet on the type field which has 2 values:
                         <codeph>beer</codeph> and <codeph>brewery</codeph>.
                     <codeblock>curl -X POST -H "Content-Type: application/json" \
-                          http://localhost:8094/api/index/bix/query \
-                          -d '{
-                          "size": 10,
-                          "query": {
-                          "boost": 1,
-                          "query": "water"
-                          },
-                          "facets": {
-                          "type": {
-                          "size": 5,
-                          "field": "type"
-                          }
-                          }
-                          }'</codeblock>
+http://localhost:8094/api/index/bix/query -d \
+'{
+    "size": 10,
+    "query": {
+        "boost": 1,
+        "query": "water"
+     },
+    "facets": {
+         "type": {
+             "size": 5,
+             "field": "type"
+         }
+    }
+}'</codeblock>
                     The result snippet below only shows the facet section for clarity. Run the curl
                     command to see the HTTP response containing the full results.
-                      <codeblock outputclass="language-json">"facets": {
-                          "type": {
-                          "field": "type",
-                          "total": 91,
-                          "missing": 0,
-                          "other": 0,
-                          "terms": [
-                          {
-                          "term": "beer",
-                          "count": 70
-                          },
-                          {
-                          "term": "brewery",
-                          "count": 21
-                          }
-                          ]
-                          }
-                          }</codeblock></li>
+                    <codeblock outputclass="language-json">"facets": {
+    "type": {
+        "field": "type",
+        "total": 91,
+        "missing": 0,
+        "other": 0,
+        "terms": [
+            {
+                "term": "beer",
+                "count": 70
+            },
+            {
+                "term": "brewery",
+                "count": 21
+            }
+        ]
+    }
+}</codeblock></li>
                   <li>Numeric Range Facet - computes facet on the <codeph>abv</codeph> field with 2
                     buckets describing <codeph>high</codeph> (greater than 7) and
                         <codeph>low</codeph> (less than 7).
                     <codeblock>curl -X POST -H "Content-Type: application/json" \
-                          http://localhost:8094/api/index/bix/query \
-                          -d '{
-                          "size": 10,
-                          "query": {
-                          "boost": 1,
-                          "query": "water"
-                          },
-                          "facets": {
-                          "abv": {
-                          "size": 5,
-                          "field": "abv",
-                          "numeric_ranges": [
-                          {
-                          "name": "high",
-                          "max": 7
-                          },
-                          {
-                          "name": "low",
-                          "min": 7
-                          }
-                          ]
-                          }
-                          }
-                          }'</codeblock>
+http://localhost:8094/api/index/bix/query -d \
+'{
+    "size": 10,
+    "query": {
+        "boost": 1,
+        "query": "water"
+    },
+    "facets": {
+        "abv": {
+            "size": 5,
+            "field": "abv",
+            "numeric_ranges": [
+                {
+                    "name": "high",
+                    "min": 7
+                },
+                {
+                    "name": "low",
+                    "max": 7
+                }
+             ]
+        }
+    }
+}'</codeblock>
                     Results:
-                      <codeblock outputclass="language-json">facets": {
-                          "abv": {
-                          "field": "abv",
-                          "total": 70,
-                          "missing": 21,
-                          "other": 0,
-                          "numeric_ranges": [
-                          {
-                          "name": "high",
-                          "max": 7,
-                          "count": 57
-                          },
-                          {
-                          "name": "low",
-                          "min": 7,
-                          "count": 13
-                          }
-                          ]
-                          }
-                          }</codeblock></li>
+                    <codeblock outputclass="language-json">facets": {
+    "abv": {
+        "field": "abv",
+        "total": 70,
+        "missing": 21,
+        "other": 0,
+        "numeric_ranges": [
+            {
+                "name": "high",
+                "min": 7,
+                "count": 13
+            },
+            {
+                "name": "low",
+                "max": 7,
+                "count": 57
+            }
+        ]
+    }
+}</codeblock></li>
               </ol>
       </section>
       </body>


### PR DESCRIPTION
I've ported the code snippet formatting
 
**from**: https://developer.couchbase.com/documentation/server/5.1/fts/fts-response-object-schema.html
**to**: https://developer.couchbase.com/documentation/server/4.6/fts/fts-queries.html

I suppose I should have asked if 4.6 is the actual branch that we last published to the website, and not something like 4.6_modified.