### PR TITLE
Add more specifics around the Request Data expected

### DIFF
--- a/content/rest-api/rest-bucket-create.dita
+++ b/content/rest-api/rest-bucket-create.dita
@@ -33,7 +33,7 @@
 			<codeblock>POST /pools/default/buckets</codeblock>
 		
 		<ul>
-			<li>Request data - List of payload parameters for the new bucket</li>
+			<li>Request data - List of payload parameters for the new bucket (in the body of the POST as x-www-form-urlencoded)</li>
 			<li>Response data - JSON of the bucket confirmation or an error condition</li>
 			<li>Authentication required - Yes </li>
 		</ul>


### PR DESCRIPTION
It may not be clear that the Request Data should be in the body of the POST as a form parameter. Someone passing the values in the URL or as JSON will get a possibly confusing response.

Since this is common in most of the endpoint documentation, do you think it would be a good idea to create a new documentation page under the REST area to explain the details of making a HTTP POST/PUT/GET etc and just link to that instead of having to put these details on every REST doc page?