### PR TITLE
Update adaptive-indexing.dita

### DIFF
--- a/content/n1ql/n1ql-language-reference/adaptive-indexing.dita
+++ b/content/n1ql/n1ql-language-reference/adaptive-indexing.dita
@@ -70,7 +70,7 @@ Q2: SELECT * FROM `travel-sample` WHERE city = "San Francisco";
 Q3: SELECT * FROM `travel-sample` WHERE faa = "SFO";</codeblock></p>
         <p>However, the following single adaptive index can serve all three of the above
             queries:<codeblock outputclass="language-json">C4: CREATE INDEX `ai_airport_day_faa` 
-    ON `travel-sample`(DISTINCT PAIRS({airportname, city, faa})) 
+    ON `travel-sample`(DISTINCT PAIRS({airportname, city, faa, type})) 
     WHERE type = "airport";</codeblock></p>
         <p>Similarly, following adaptive index over SELF (that includes all fields in the documents)
       is also qualified for these queries. In fact, the index in C5 can serve any query on the


### PR DESCRIPTION
Fields in WHERE predicate are required in the index projection.  Otherwise the planner will not use the index.