### PR TITLE
Update full access bucket role to 'bucket_full_access'

### DIFF
--- a/content/security/concepts-rba-for-apps.dita
+++ b/content/security/concepts-rba-for-apps.dita
@@ -112,7 +112,7 @@
          <thead>
            
            <row>
-             <entry rowsep="1" namest="c1" nameend="c6" align="center">Role: Bucket Full Access (<codeph>bucket_admin</codeph>)</entry>
+             <entry rowsep="1" namest="c1" nameend="c6" align="center">Role: Bucket Full Access (<codeph>bucket_full_access</codeph>)</entry>
            </row>
            
            <row>

--- a/content/security/concepts-rba-for-apps.dita
+++ b/content/security/concepts-rba-for-apps.dita
@@ -112,7 +112,7 @@
          <thead>
            
            <row>
-             <entry rowsep="1" namest="c1" nameend="c6" align="center">Role: Bucket Full Access (<codeph>bucket_sasl</codeph>)</entry>
+             <entry rowsep="1" namest="c1" nameend="c6" align="center">Role: Bucket Full Access (<codeph>bucket_admin</codeph>)</entry>
            </row>
            
            <row>


### PR DESCRIPTION
The full bucket access role name should be 'bucket_full_access' not 'bucket_sasl'.

If the current value of 'bucket_sasl' is used, a 400 (Bad Request) response is returned from the server. I've tested this on 5.0, 5.1 and 5.5-beta.

NOTE: I originally used 'bucket_admin' but this is not available in CE edition where 'bucket_full_access' is.