### PR TITLE
DOC-70

### DIFF
--- a/content/sdk/core-operations.dita
+++ b/content/sdk/core-operations.dita
@@ -168,10 +168,10 @@ docid                CAS=0x8234c3c0f213, Flags=0x0. Size=16
                 retrieved<codeblock outputclass="language-python">name, email = cb.retrieve_in('user:kingarthur', 'contact.name', 'contact.email')</codeblock></p></section>
         <section id="devguide_kvcore_counter_generic"><title>Counters</title><p>You can atomically
                 increment or decrement the numerical value of special counter document </p>
-              <note type="note">Do not increment counters if using XDCR. Within a single cluster the <codeph>incr()</codeph> is atomic;
-                 across XDCR however, if two clients connecting to two different (bi-directional) 
+              <note type="note">Do not increment or decrement counters if using XDCR. Within a single cluster the <codeph>incr()</codeph> is atomic, as is <codeph>decr()</codeph>;
+                 across XDCR however, if two clients connecting to two different (bidirectional) 
                 clusters issue <codeph>incr</codeph> concurrently, this may (and most likely will) result in the 
-                value only getting incremented once in total.</note>
+                value only getting incremented once in total. The same is the case for <codeph>decr()</codeph>.</note>
             A document may be used as a counter if its value is a simple ASCII number, like
                 <codeph>42</codeph>. Couchbase allows you to increment and decrement these values
             atomically using a special <apiname>counter</apiname> operation. The example below (in

--- a/content/sdk/core-operations.dita
+++ b/content/sdk/core-operations.dita
@@ -167,8 +167,12 @@ docid                CAS=0x8234c3c0f213, Flags=0x0. Size=16
                     operations</xref>, by specifying one or more sections of the document to be
                 retrieved<codeblock outputclass="language-python">name, email = cb.retrieve_in('user:kingarthur', 'contact.name', 'contact.email')</codeblock></p></section>
         <section id="devguide_kvcore_counter_generic"><title>Counters</title><p>You can atomically
-                increment or decrement the numerical value of special counter document </p>A
-            document may be used as a counter if its value is a simple ASCII number, like
+                increment or decrement the numerical value of special counter document </p>
+              <note type="note">Do not increment counters if using XDCR. Within a single cluster the <codeph>incr()</codeph> is atomic;
+                 across XDCR however, if two clients connecting to two different (bi-directional) 
+                clusters issue <codeph>incr</codeph> concurrently, this may (and most likely will) result in the 
+                value only getting incremented once in total.</note>
+            A document may be used as a counter if its value is a simple ASCII number, like
                 <codeph>42</codeph>. Couchbase allows you to increment and decrement these values
             atomically using a special <apiname>counter</apiname> operation. The example below (in
             Python) shows how to use


### PR DESCRIPTION
XDCR: Document that atomic INCR/DECR should not be relied on across an XDCR relationship