### PR TITLE
Fixing misspelling in sdk-xattr-example 

### DIFF
--- a/content/sdk/go/sdk-xattr-example.dita
+++ b/content/sdk/go/sdk-xattr-example.dita
@@ -50,7 +50,7 @@ import (
 func main() {
     cluster, _ := gocb.Connect("couchbase://localhost")
     cluster.Authenticate(gocb.PasswordAuthenticator{
-        Username: "Administrator",main.go
+        Username: "Administrator",
         Password: "password",
     })
 


### PR DESCRIPTION
`gocb.PasswordAuthenticator{
		Username: "Administrator",main.go
		Password: "password",
	}
`

to

`gocb.PasswordAuthenticator{
		Username: "Administrator",
		Password: "password",
	}
`