### PR TITLE
fix missing command line options in documentation

### DIFF
--- a/content/sdk/development-intro.dita
+++ b/content/sdk/development-intro.dita
@@ -64,7 +64,7 @@
             <title>Reading documents by ID</title>
             <p>Documents can be retrieved using their IDs. Retrieving a document by ID is extremely
                 fast. The following query takes about 1 millisecond.</p>
-            <screen>$ <b>cbc cat -u <varname>username</varname> -P <varname>password</varname> -U couchbase://<varname>hostname-or-ip</varname>mnunberg</b>
+            <screen>$ <b>cbc cat -u <varname>username</varname> -P <varname>password</varname> -U couchbase://<varname>hostname-or-ip</varname>/mnunberg</b>
 {
     "name": "Mark Nunberg",
     "email": "mark.nunberg@couchbase.com",

--- a/content/sdk/development-intro.dita
+++ b/content/sdk/development-intro.dita
@@ -57,14 +57,14 @@
     "likes": ["doge", "pastries"]
 }</codeblock><p>Now,
                 insert the document into Couchbase using the <i><codeph>cbc</codeph></i>
-                utility:</p><screen>$ <b>cbc create --mode insert mnunberg &lt; mnunberg.json</b></screen><codeph>mnunberg</codeph>
+          utility:</p><screen>$ <b>cbc create -u <varname>username</varname> -P <varname>password</varname> -U couchbase://<varname>hostname-or-ip</varname>/default --mode insert mnunberg &lt; mnunberg.json</b></screen><codeph>mnunberg</codeph>
             is the document’s ID, which is redirected (<codeph>&lt;</codeph>) to the
                 <cmdname>cbc</cmdname> command’s standard input.</section>
         <section>
             <title>Reading documents by ID</title>
             <p>Documents can be retrieved using their IDs. Retrieving a document by ID is extremely
                 fast. The following query takes about 1 millisecond.</p>
-            <screen>$ <b>cbc cat mnunberg</b>
+            <screen>$ <b>cbc cat -u <varname>username</varname> -P <varname>password</varname> -U couchbase://<varname>hostname-or-ip</varname>mnunberg</b>
 {
     "name": "Mark Nunberg",
     "email": "mark.nunberg@couchbase.com",


### PR DESCRIPTION
Some missing options in the sample `cbc` command caused the command does not work.