### PR TITLE
Vulcan RTO updates

### DIFF
--- a/content/sdk/dotnet/threshold-logging.dita
+++ b/content/sdk/dotnet/threshold-logging.dita
@@ -4,40 +4,39 @@
   <title>Threshold Logging Tracing through the SDK</title>
   <titlealts><navtitle>Threshold Logging</navtitle></titlealts>
     <shortdesc conref="../shared/tracing.dita#tracing/shortdesc"/>
-    
+
     <body>
         <section conref="../shared/tracing.dita#tracing/why_tracing">
         </section>
 
         <section conref="../shared/tracing.dita#tracing/open_tracing">
         </section>
-        
+
         <section conref="../shared/tracing.dita#tracing/threshold_configuration">
         </section>
 
-            
+
         <section id="tracing_dot_net">
             <title>
                 Threshold Logging in .NET
             </title>
-            
-            <p>
-              Here is the code to override the default values of the tracer:<codeblock>int interval = 5000; // 5 seconds
-int sampleSize = 20;
-Dictionary&lt;string, int> serviceFloors = new Dictionary&lt;string, int>
-{
-    {"kv", 500000}, // 500 milliseconds
-    {"view", 1000000}, // 1 second
-    {"n1ql", 1000000}, // 1 second
-    {"search", 1000000}, // 1 second
-    {"analytics", 1000000} // 1 second
-};
 
-var tracer = new ThresholdLoggingTracer(interval, sampleSize, serviceFloors);
+            <p>
+              Here is the code to override the default values of the tracer:<codeblock>
+var tracer = new ThresholdLoggingTracer
+{
+    Interval = 5000, // 5 seconds
+    SampleSize = 5,
+    KvThreshold = 500000, // 500 ms
+    ViewThreshold = 1000000, // 1 second
+    N1qlThreshold = 1000000, // 1 second
+    SearchThreshold = 1000000, // 1 second
+    AnalyticsThreshold = 1000000 // 1 second
+};
 var config = new ClientConfiguration();
 config.Tracer = tracer;
 
-var cluster = new Cluster(config);</codeblock>.
+var cluster = new Cluster(config);</codeblock>
             </p>
         </section>
     </body>

--- a/content/sdk/shared/tracing.dita
+++ b/content/sdk/shared/tracing.dita
@@ -48,25 +48,22 @@
                     <tbody>
                         <row>
                             <entry><codeph>OperationTracingEnabled</codeph></entry>
-                            <entry>Boolean used to determine tracing is enabled. Defaults to using the 
-                                <codeph>ThesholdLoggingTracer</codeph> if enabled. When false a Noop or similar tracing 
+                            <entry>Boolean used to determine tracing is enabled. Defaults to using the
+                                <codeph>ThesholdLoggingTracer</codeph> if enabled. When false a Noop or similar tracing
                                 implementation should be used instead.</entry>
                             <entry>true</entry>
                         </row>
                         <row>
                             <entry><codeph>OperationTracingServerDurationEnabled</codeph></entry>
-                            <entry>Boolean used to instruct the SDK to try and retrieve duration metrics from the server. 
-                                This is done in a different way depending on the service type.
-                            For KV engine: Controls if the <codeph>Framing Extras hello</codeph> flag is issued during 
-                                socket setup.</entry>
+                            <entry>Boolean used to instruct the SDK to try and retrieve duration metrics from the server for KV operations.</entry>
                             <entry>true</entry>
                         </row>
                         <row>
                             <entry><codeph>ThresholdLoggingTracerInterval</codeph></entry>
-                            <entry>The interval between executions that processes the collected operation spans. 
+                            <entry>The interval between executions that processes the collected operation spans.
                                 Expressed in milliseconds.
 </entry>
-                            <entry>60,000 (1 minute)</entry>
+                            <entry>10,000 (10 seconds)</entry>
                         </row>
                         <row>
                             <entry><codeph>ThresholdLoggingTracerSampleSize</codeph></entry>
@@ -74,35 +71,50 @@
                             <entry>10</entry>
                         </row>
                         <row>
-                            <entry><codeph>ThresholdLoggingTracerKVFloor</codeph></entry>
+                            <entry><codeph>ThresholdLoggingTracerKVThreshold</codeph></entry>
                             <entry>The KV operation operation threshold. Expressed in microseconds.</entry>
                             <entry>500,000 (500 milliseconds)</entry>
                         </row>
                         <row>
-                            <entry><codeph>ThresholdLoggingTracerViewsFloor</codeph></entry>
+                            <entry><codeph>ThresholdLoggingTracerViewsThreshold</codeph></entry>
                             <entry>The View query operation threshold. Expressed in microseconds.</entry>
                             <entry>1,000,000 (1 second)</entry>
                         </row>
                         <row>
-                            <entry><codeph>ThresholdLoggingTracerQueryFloor</codeph></entry>
+                            <entry><codeph>ThresholdLoggingTracerQueryThreshold</codeph></entry>
                             <entry>The N1QL query operation threshold. Expressed in microseconds.</entry>
                             <entry>1,000,000 (1 second)</entry>
                         </row>
                         <row>
-                            <entry><codeph>ThresholdLoggingTracerSearchFloor</codeph></entry>
+                            <entry><codeph>ThresholdLoggingTracerSearchThreshold</codeph></entry>
                             <entry>The FTS query operation threshold. Expressed in microseconds.</entry>
                             <entry>1,000,000 (1 second)</entry>
                         </row>
                         <row>
-                            <entry><codeph>ThresholdLoggingTracerAnalyticsFloor</codeph></entry>
+                            <entry><codeph>ThresholdLoggingTracerAnalyticsThreshold</codeph></entry>
                             <entry>The Analytics query operation threshold. Expressed in microseconds.</entry>
                             <entry>1,000,000 (1 second)</entry>
+                        </row>
+                        <row>
+                            <entry><codeph>OrphanedResponseLoggingEnabled</codeph></entry>
+                            <entry>Boolean used to determine if orphaned response logging is enabled.</entry>
+                            <entry>true</entry>
+                        </row>
+                        <row>
+                            <entry><codeph>OrphanedResponseLoggingInterval</codeph></entry>
+                            <entry>The interval used to flush orphaned response information to the log. Expressed in microseconds.</entry>
+                            <entry>10,000 (10 seconds)</entry>
+                        </row>
+                        <row>
+                            <entry><codeph>OrphanedResponseLoggingSampleSize</codeph></entry>
+                            <entry>The number of sample orphaned responses whose to log additional information for per execution.</entry>
+                            <entry>10</entry>
                         </row>
                     </tbody>
                 </tgroup>
         </table>
 
-            
+
         </section>
     </body>
 </topic>


### PR DESCRIPTION
- update threshold logging configuration names / defaults
- add orphan / zombie response logging configuration properties (maybe these need to be separate?)
- update .NET code example to update Threshold tracer default values

Also looks like my VS Code editor picked up some whitespace and removed it too.