### PR TITLE
DOC-1332

### DIFF
--- a/content/rest-api/rest-xdcr-statistics.dita
+++ b/content/rest-api/rest-xdcr-statistics.dita
@@ -20,18 +20,18 @@
             <section><title>HTTP method and URI</title>
                 
                 <p>The destination endpoint follows the
-                    <codeph>/pools/default/buckets/@xdcr_[bucket_name]/stats/</codeph> URI endpoint:</p>
-                <codeblock>GET /pools/default/buckets/@xdcr_[bucket_name]/stats/[destination_endpoint]               </codeblock>
+                    <codeph>/pools/default/buckets/@xdcr-[bucket_name]/stats/</codeph> URI endpoint:</p>
+                <codeblock>GET /pools/default/buckets/@xdcr-[bucket_name]/stats/[destination_endpoint]               </codeblock>
                 
                 <p>Where the destination endpoint is:</p>
                 <codeblock>replications/[remote_UUID]/[source_bucket]/[destination_bucket]/[stat_name]</codeblock>
                 
                 <p>Where the HTTP endpoint string with full URI is:</p>
-                <codeblock>http://[localhost]:[port]/pools/default/buckets/[bucket_name]/stats/replications/ \
+                <codeblock>http://[localhost]:[port]/pools/@xdcr-default/buckets/[bucket_name]/stats/replications/ \
   [remote_UUID]/[source_bucket]/[destination_bucket]/[stat_name]                </codeblock>
                 
                 <p>Where the HTTP string with a properly URL-encoded URI is:</p>
-                <codeblock>http://[localhost]:[port]/pools/default/buckets/[bucket_name]/stats/ \
+                <codeblock>http://[localhost]:[port]/pools/@xdcr-default/buckets/[bucket_name]/stats/ \
     replications%2F[remote_UUID]%2F[source_bucket]%2F[destination_bucket]%2F[stat_name]</codeblock>
                 
                 
@@ -189,7 +189,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
         <title>Retrieving <codeph>docs_written</codeph> stats</title>
         <refbody>
             <section><title>HTTP method and URI</title>
-                <codeblock>GET /pools/default/buckets/@xdcr_[bucket_name]/stats/[destination_endpoint]</codeblock>
+                <codeblock>GET /pools/default/buckets/@xdcr-[bucket_name]/stats/[destination_endpoint]</codeblock>
                 
                 <p>Where the [destination_endpoint] is:</p>
                 <codeblock>replications/[remote_UUID]/[source_bucket]/[destination_bucket]/docs_written </codeblock>
@@ -199,14 +199,14 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
             <section><title>Syntax</title>
                 <p>Curl request syntax for number of documents written:</p>
                 <codeblock>curl -u [admin]:[password] 
-    http://[localhost]:8091/pools/default/buckets/default/stats/ 
+    http://[localhost]:8091/pools/default/buckets/@xdcr-default/stats/ 
     replications%2F[remote_UUID]%2F[source_bucket]%2F[destination_bucket]%2Fdocs_written </codeblock>
             </section>
         
         <section><title>Example</title>
         <p>To get the number of documents written:</p>
         <codeblock>curl -u Administrator:password \ 
-    http://10.5.2.54:8091/pools/default/buckets/default/stats/ \
+    http://10.5.2.54:8091/pools/default/buckets/@xdcr-default/stats/ \
     replications%2F8ba6870d88cd72b3f1db113fc8aee675%2Fsource_bucket%2Fdestination_bucket%2Fdocs_written</codeblock>
        
         </section>
@@ -237,7 +237,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
     <refbody>
         
         <section><title>HTTP method and URI</title>
-            <codeblock>GET /pools/default/buckets/@xdcr_[bucket_name]/stats/[destination_endpoint] </codeblock>
+            <codeblock>GET /pools/default/buckets/@xdcr-[bucket_name]/stats/[destination_endpoint] </codeblock>
             
             <p>Where the [destination_endpoint] is:</p>
             <codeblock>replications/[remote_UUID]/[source_bucket]/[destination_bucket]/rate_replication </codeblock>
@@ -255,7 +255,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
         <section><title>Example</title>
             <p>Curl request example to get the rate of replication:</p>
         <codeblock>curl -u Administrator:password \
-    http://10.5.2.54:8091/pools/default/buckets/default/stats/ \
+    http://10.5.2.54:8091/pools/default/buckets/@xdcr-default/stats/ \
     replications%2F8ba6870d88cd72b3f1db113fc8aee675%2Fsource_bucket%2Fdestination_bucket%2Frate_replication</codeblock>
         
         </section>
@@ -282,7 +282,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
         <refbody>
             
             <section><title>HTTP method and URI</title>
-                <codeblock>GET /pools/default/buckets/@xdcr_[bucket_name]/stats/[destination_endpoint]                </codeblock>
+                <codeblock>GET /pools/default/buckets/@xdcr-[bucket_name]/stats/[destination_endpoint]                </codeblock>
                 
                 <p>Where the [destination_endpoint] is:</p>
                 <codeblock>replications/[remote_UUID]/[source_bucket]/[destination_bucket]/docs_opt_repd</codeblock>
@@ -316,7 +316,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
         <p>With this replication id, retrieve a sampling of stats for <codeph>docs_opt_repd</codeph>:</p>
                 
             <codeblock>curl -s -u Administrator:password \
-http://10.3.121.119:8091/pools/default/buckets/default/stats/ \
+http://10.3.121.119:8091/pools/default/buckets/@xdcr-default/stats/ \
 replications%2fdef03dbf5e968a47309194ebe052ed21%2fbucket_source%2fbucket_destination%2fdocs_opt_repd </codeblock>
             </section>
             

--- a/content/rest-api/rest-xdcr-statistics.dita
+++ b/content/rest-api/rest-xdcr-statistics.dita
@@ -20,18 +20,18 @@
             <section><title>HTTP method and URI</title>
                 
                 <p>The destination endpoint follows the
-                    <codeph>/pools/default/buckets/@xdcr-[bucket_name]/stats/</codeph> URI endpoint:</p>
-                <codeblock>GET /pools/default/buckets/@xdcr-[bucket_name]/stats/[destination_endpoint]               </codeblock>
+                    <codeph>/pools/default/buckets/@xdcr-[source_bucket]/stats/</codeph> URI endpoint:</p>
+                <codeblock>GET /pools/default/buckets/@xdcr-[source_bucket]/stats/[destination_endpoint]               </codeblock>
                 
                 <p>Where the destination endpoint is:</p>
                 <codeblock>replications/[remote_UUID]/[source_bucket]/[destination_bucket]/[stat_name]</codeblock>
                 
                 <p>Where the HTTP endpoint string with full URI is:</p>
-                <codeblock>http://[localhost]:[port]/pools/@xdcr-default/buckets/[bucket_name]/stats/replications/ \
+                <codeblock>http://[node address]:[port]/pools/@xdcr-[source_bucket]/buckets/[bucket_name]/stats/replications/ \
   [remote_UUID]/[source_bucket]/[destination_bucket]/[stat_name]                </codeblock>
                 
                 <p>Where the HTTP string with a properly URL-encoded URI is:</p>
-                <codeblock>http://[localhost]:[port]/pools/@xdcr-default/buckets/[bucket_name]/stats/ \
+                <codeblock>http://[node address]:[port]/pools/@xdcr-[source_bucket]/buckets/[bucket_name]/stats/ \
     replications%2F[remote_UUID]%2F[source_bucket]%2F[destination_bucket]%2F[stat_name]</codeblock>
                 
                 
@@ -189,7 +189,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
         <title>Retrieving <codeph>docs_written</codeph> stats</title>
         <refbody>
             <section><title>HTTP method and URI</title>
-                <codeblock>GET /pools/default/buckets/@xdcr-[bucket_name]/stats/[destination_endpoint]</codeblock>
+                <codeblock>GET /pools/default/buckets/@xdcr-[source_bucket]/stats/[destination_endpoint]</codeblock>
                 
                 <p>Where the [destination_endpoint] is:</p>
                 <codeblock>replications/[remote_UUID]/[source_bucket]/[destination_bucket]/docs_written </codeblock>
@@ -199,7 +199,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
             <section><title>Syntax</title>
                 <p>Curl request syntax for number of documents written:</p>
                 <codeblock>curl -u [admin]:[password] 
-    http://[localhost]:8091/pools/default/buckets/@xdcr-default/stats/ 
+    http://[node address]:8091/pools/default/buckets/@xdcr-[source_bucket]/stats/ 
     replications%2F[remote_UUID]%2F[source_bucket]%2F[destination_bucket]%2Fdocs_written </codeblock>
             </section>
         
@@ -207,7 +207,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
         <p>To get the number of documents written:</p>
         <codeblock>curl -u Administrator:password \ 
     http://10.5.2.54:8091/pools/default/buckets/@xdcr-default/stats/ \
-    replications%2F8ba6870d88cd72b3f1db113fc8aee675%2Fsource_bucket%2Fdestination_bucket%2Fdocs_written</codeblock>
+    replications%2F8ba6870d88cd72b3f1db113fc8aee675%2Fdefault%2Fdefault%2Fdocs_written</codeblock>
        
         </section>
             
@@ -237,7 +237,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
     <refbody>
         
         <section><title>HTTP method and URI</title>
-            <codeblock>GET /pools/default/buckets/@xdcr-[bucket_name]/stats/[destination_endpoint] </codeblock>
+            <codeblock>GET /pools/default/buckets/@xdcr-[source_bucket]/stats/[destination_endpoint] </codeblock>
             
             <p>Where the [destination_endpoint] is:</p>
             <codeblock>replications/[remote_UUID]/[source_bucket]/[destination_bucket]/rate_replication </codeblock>
@@ -247,7 +247,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
         <section><title>Syntax</title>
             <p>Curl request syntax:</p>
             <codeblock>curl -u [admin]:[password] 
-    http://[localhost]:8091/pools/default/buckets/default/stats/ 
+    http://[node address]:8091/pools/default/buckets/[source_bucket]/stats/ 
     replications%2F[remote_UUID]%2F[source_bucket]%2F[destination_bucket]%2Frate_replication </codeblock>
         
         </section>
@@ -256,7 +256,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
             <p>Curl request example to get the rate of replication:</p>
         <codeblock>curl -u Administrator:password \
     http://10.5.2.54:8091/pools/default/buckets/@xdcr-default/stats/ \
-    replications%2F8ba6870d88cd72b3f1db113fc8aee675%2Fsource_bucket%2Fdestination_bucket%2Frate_replication</codeblock>
+    replications%2F8ba6870d88cd72b3f1db113fc8aee675%2Fdefault%2Fdefault%2Frate_replication</codeblock>
         
         </section>
         
@@ -282,7 +282,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
         <refbody>
             
             <section><title>HTTP method and URI</title>
-                <codeblock>GET /pools/default/buckets/@xdcr-[bucket_name]/stats/[destination_endpoint]                </codeblock>
+                <codeblock>GET /pools/default/buckets/@xdcr-[source_bucket]/stats/[destination_endpoint]                </codeblock>
                 
                 <p>Where the [destination_endpoint] is:</p>
                 <codeblock>replications/[remote_UUID]/[source_bucket]/[destination_bucket]/docs_opt_repd</codeblock>
@@ -291,7 +291,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
             
             <section><title>Syntax: get replication id</title>
                 <codeblock>curl -s -u admin:password \
-    http://[localhost]:8091/pools/default/tasks</codeblock>
+    http://[node address]:8091/pools/default/tasks</codeblock>
             </section>
         
         <section><title>Example: get replication id</title>
@@ -317,7 +317,7 @@ curl -u Administrator:password http://10.5.2.54:8091/pools/default/remoteCluster
                 
             <codeblock>curl -s -u Administrator:password \
 http://10.3.121.119:8091/pools/default/buckets/@xdcr-default/stats/ \
-replications%2fdef03dbf5e968a47309194ebe052ed21%2fbucket_source%2fbucket_destination%2fdocs_opt_repd </codeblock>
+replications%2fdef03dbf5e968a47309194ebe052ed21%2fdefault%2fdefault%2fdocs_opt_repd </codeblock>
             </section>
             
             <section><title>Response</title>
@@ -349,7 +349,7 @@ replications%2fdef03dbf5e968a47309194ebe052ed21%2fbucket_source%2fbucket_destina
                 <p>Curl request syntax:</p>
                 
                 <codeblock>curl -u [admin]:[password] -X GET
-    http://[Destination_IP]:8091/pools/default/buckets/[bucket_name]/stats</codeblock>
+    http://[Destination_IP]:8091/pools/default/buckets/[destination bucket]/stats</codeblock>
         </section>
             
             <section><title>Example</title>


### PR DESCRIPTION
Fixed issues with bucket name and stats endpoint for REST XDCR stats where the naming is given incorrectly as `@xdcr_` instead of `@xdcr-`. Should fix problem in DOC-1332.

Needs porting to other version 4.x and current 5.x docs.