### PR TITLE
Documentation correction on data_reader_writer role

### DIFF
--- a/content/cli/cbcli/couchbase-cli-user-manage.dita
+++ b/content/cli/cbcli/couchbase-cli-user-manage.dita
@@ -271,17 +271,17 @@ data_reader[…]
         <i outputclass="db.emphasis">default</i> and <i outputclass="db.emphasis">app</i>, then set their role as data_reader[default,app].
 </p>
 </dd></dlentry><dlentry outputclass="db.varlistentry"><dt outputclass="db.term">
-data_reader_writer[…]
+data_writer[…]
 </dt><dd outputclass="db.listitem">
 <p outputclass="db.simpara">
         Gives the user permission to read and write data through Couchbases
         key-value APIs. The user cannot however modify the settings of a bucket.
         To give a user read-write access for all buckets set their role to
-        data_reader_writer[*]. To give the user read-write access to data on a
+        data_writer[*]. To give the user read-write access to data on a
         single bucket named <i outputclass="db.emphasis">default</i> then specify their role as
-        data_reader_writer[default]. If the user needs read-write access to data
+        data_writer[default]. If the user needs read-write access to data
         for multiple buckets, for example <i outputclass="db.emphasis">default</i> and <i outputclass="db.emphasis">app</i>, then set their role
-        as data_reader_writer[default,app].
+        as data_writer[default,app].
 </p>
 </dd></dlentry><dlentry outputclass="db.varlistentry"><dt outputclass="db.term">
 data_dcp_reader[…]


### PR DESCRIPTION
Looks like it's just data_writer, but otherwise correct.