### PR TITLE
Update .NET API ref link to 2.6.0 release

### DIFF
--- a/content/sdk/dotnet/start-using-sdk.dita
+++ b/content/sdk/dotnet/start-using-sdk.dita
@@ -230,7 +230,7 @@ var bucket = cluster.OpenBucket("bucketname");</codeblock>
 		</section>
 
 		<section><title>API Reference</title>The API reference is generated for each release and can
-			be found <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.4.7/" format="html"
+			be found <xref href="http://docs.couchbase.com/sdk-api/couchbase-net-client-2.6.0/" format="html"
 				scope="external">here</xref>. </section>
 		<section><title>Contributing</title><p>Couchbase welcomes community contributions to the
 				.NET SDK. The <xref href="https://github.com/couchbase/couchbase-net-client"


### PR DESCRIPTION
This will need back porting to older documentation versions too