### PR TITLE
DOC-3257: update cbcollect_info arguments and examples

### DIFF
--- a/content/cli/cbcollect-info-tool.dita
+++ b/content/cli/cbcollect-info-tool.dita
@@ -274,14 +274,14 @@
 						
 						<row>
 							<entry><codeph>-r ROOT</codeph></entry>
-							<entry>Specifies the root directory. Defaults on Linux to
-								<codeph>/opt/couchbase/bin/..</codeph></entry>
+							<entry>Specifies the root directory. Defaults to the parent directory of the directory containing
+              cbcollect_info, e.g. <codeph>/opt/couchbase/bin/..</codeph> on Linux.</entry>
 						</row>
 						
 						<row>
 							<entry><codeph>-v</codeph></entry>
-							<entry>Increases the verbosity level: debugging information
-								will thereby be included in the console-display. </entry>
+							<entry>Increases the verbosity level: If specified, debugging information
+								will be included in the console display.</entry>
 						</row>
 						
 						<row>
@@ -301,13 +301,13 @@
 						
 						<row>
 							<entry><codeph>--task-regexp=TASK_REGEXP</codeph></entry>
-							<entry>Runs only those tasks that match the specified regexp. (This flag is provided
+							<entry>Runs only those tasks that match the specified regular expression. (This flag is provided
 							for debugging purposes.)</entry>
 						</row>
 						
 						<row>
 							<entry><codeph>--tmp-dir=TMP_DIR</codeph></entry>
-							<entry>Specifies the <codeph>tmp</codeph> directory that is used during data-processing. This setting overrides any
+							<entry>Specifies the <codeph>tmp</codeph> directory that is used during data processing. This setting overrides any
 								existing setting of the <codeph>TMPDIR</codeph> environment variable.</entry>
 						</row>
 						
@@ -325,7 +325,7 @@
 						
 						<row>
 							<entry><codeph>--log-redaction-level=REDACT_LEVEL</codeph></entry>
-							<entry>Specifies the redaction level for the logs collected; which can be either 
+							<entry>Specifies the redaction level for the logs collected. The level can be either 
 								<codeph>none</codeph> (the default) or <codeph>partial</codeph>.</entry>
 						</row>
 						

--- a/content/cli/cbcollect-info-tool.dita
+++ b/content/cli/cbcollect-info-tool.dita
@@ -119,25 +119,54 @@
 					</thead>
 					<tbody>
 						<row>
+							<entry><codeph>cbcollect_info.log</codeph></entry>
+							<entry>Contains information about the performance of <cmdname>cbcollect_info</cmdname>.</entry>
+						</row>
+						<row>
 							<entry><codeph>couchbase.log</codeph></entry>
 							<entry>Contains system-level information, primarily the result of shell commands. Generated at collection-time.</entry>
 						</row>
 						<row>
 							<entry><codeph>ddocs.log</codeph></entry>
-							<entry>Contains the design documents for each bucket in json format, taken from the view file on disk.</entry>
+							<entry>Contains the design documents for each bucket in JSON format, taken from the view file on disk.</entry>
 						</row>
 						<row>
 							<entry><codeph>diag.log</codeph></entry>
 							<entry>A diagnostic summary of the cluster manager, obtained by downloading <codeph>/diag</codeph> output from the node's running service.</entry>
 						</row>
 						<row>
+							<entry><codeph>kv_trace.json</codeph></entry>
+							<entry>Metadata used for Phosphor KV tracing.</entry>
+						</row>
+						<row>
 							<entry><codeph>ini.log</codeph></entry>
 							<entry>A dump of all ini configuration files.</entry>
 						</row>
 						<row>
+							<entry><codeph>master_events.log</codeph></entry>
+              <entry>Contains major events that have affected the cluster, like bucket creation, and rebalance 
+              information such as vBucket movement.</entry>
+						</row>
+						<row>
 							<entry><codeph>memcached.log</codeph></entry>
-							<entry>Contains information relating to the core memcached component,
+							<entry>Contains information relating to the core <apiname>memcached</apiname> component,
 								including DCP stream requests and slow operations.</entry>
+						</row>
+						<row>
+							<entry><codeph>ns_server.analytics.log</codeph></entry>
+							<entry>(Developer Preview.)</entry>
+						</row>
+						<row>
+							<entry><codeph>ns_server.analytics_debug.log</codeph></entry>
+							<entry>(Developer Preview.)</entry>
+						</row>
+						<row>
+							<entry><codeph>ns_server.analytics_shutdown.log</codeph></entry>
+							<entry>(Developer Preview.)</entry>
+						</row>
+						<row>
+							<entry><codeph>ns_server.analytics_trace.log</codeph></entry>
+							<entry>(Developer Preview.)</entry>
 						</row>
 						<row>
 							<entry><codeph>ns_server.babysitter.log</codeph></entry>
@@ -148,7 +177,7 @@
 						<row>
 							<entry><codeph>ns_server.couchdb.log</codeph></entry>
 							<entry>Troubleshooting log for the couchdb subsystem which underlies
-								map-reduce and spatial views</entry>
+								map-reduce and spatial views.</entry>
 						</row>
 						<row>
 							<entry><codeph>ns_server.debug.log</codeph></entry>
@@ -158,6 +187,10 @@
 						<row>
 							<entry><codeph>ns_server.error.log</codeph></entry>
 							<entry>Error-level troubleshooting log for the cluster management component.</entry>
+						</row>
+						<row>
+							<entry><codeph>ns_server.eventing.log</codeph></entry>
+							<entry>Eventing service logs.</entry>
 						</row>
 						<row>
 							<entry><codeph>ns_server.fts.log</codeph></entry>
@@ -188,6 +221,10 @@
 							<entry>Info-level troubleshooting log for the cluster management component.</entry>
 						</row>
 						<row>
+							<entry><codeph>ns_server.json_rpc.log</codeph></entry>
+							<entry>JSON RPC logs.</entry>
+						</row>
+						<row>
 							<entry><codeph>ns_server.mapreduce_errors.log</codeph></entry>
 							<entry>JavaScript and other view-processing errors are reported in this
 								file.</entry>
@@ -204,6 +241,10 @@
 							<entry><codeph>ns_server.projector.log</codeph></entry>
 							<entry>Troubleshooting log for the projector process which is responsible for sending 
 								appropriate mutations from Data nodes to Index nodes.</entry>
+						</row>
+						<row>
+							<entry><codeph>ns_server.query.log</codeph></entry>
+							<entry>Query service logs.</entry>
 						</row>
 						<row>
 							<entry><codeph>ns_server.reports.log</codeph></entry>
@@ -231,6 +272,10 @@
 							<entry>Error-level troubleshooting log for the cross datacenter replication (XDCR) component used in Couchbase Server versions prior to 4.0.</entry>
 						</row>
 						<row>
+							<entry><codeph>ns_server.xdcr_target.log</codeph></entry>
+							<entry>Log of traces from cross datacenter replication (XDCR) target endpoint handlers.</entry>
+						</row>
+						<row>
 							<entry><codeph>ns_server.xcdr_trace.log</codeph></entry>
 							<entry>Trace-level troubleshooting log for the cross datacenter replication (XDCR) component used in Couchbase Server versions prior to 4.0. 
 								Unless trace-level logging is explicitly turned on this log is empty.</entry>
@@ -246,6 +291,10 @@
 						<row>
 							<entry><codeph>syslog.tar.gz</codeph></entry>
 							<entry>Archive of various system-level logs.</entry>
+						</row>
+						<row>
+							<entry><codeph>systemd_journal.gz</codeph></entry>
+							<entry>(Linux only.) The logs from <apiname>systemd</apiname>.</entry>
 						</row>
 					</tbody>
 				</tgroup>
@@ -275,7 +324,7 @@
 						<row>
 							<entry><codeph>-r ROOT</codeph></entry>
 							<entry>Specifies the root directory. Defaults to the parent directory of the directory containing
-              cbcollect_info, e.g. <codeph>/opt/couchbase/bin/..</codeph> on Linux.</entry>
+              <cmdname>cbcollect_info</cmdname>, e.g. <codeph>/opt/couchbase/bin/..</codeph> on Linux.</entry>
 						</row>
 						
 						<row>
@@ -291,7 +340,7 @@
 						
 						<row>
 							<entry><codeph>-d</codeph></entry>
-							<entry>Dumps a list of commands required by <codeph>cbcollect_info</codeph>.</entry>
+							<entry>Dumps a list of commands required by <cmdname>cbcollect_info</cmdname>.</entry>
 						</row>
 						
 						<row>
@@ -376,41 +425,61 @@
 		</section>
 		
 		<section><title>Examples</title>
-			<p>To create a diagnostics .zip file, log onto the node and run the <codeph>cbcollect_info</codeph> tool.</p>
+			<p>To create a diagnostics .zip file, log onto the node and run the <cmdname>cbcollect_info</cmdname> tool.</p>
 			<p>On Linux, run as root or use sudo: <codeblock>sudo /opt/couchbase/bin/cbcollect_info &lt;node_name&gt;.zip</codeblock></p>
 			<p>On Windows, run as Administrator: <codeblock>C:\Program Files\Couchbase\Server\bin\cbcollect_info &lt;node_name&gt;.zip</codeblock></p>
 			
 	<p><b>Response</b></p>
 			
-			<p>The following example response shows partial output when running the <codeph>cbcollect_info</codeph> command.</p>
-			<codeblock>uname (uname -a) - OK
+			<p>The following example response shows partial output when running the <cmdname>cbcollect_info</cmdname> command.</p>
+			<codeblock>Using temporary dir /tmp
+Log Redaction () - OK
+uname (uname -a) - OK
 time and TZ (date; date -u) - OK
-raw /etc/sysconfig/clock (cat /etc/sysconfig/clock) - OK
-raw /etc/timezone (cat /etc/timezone) - Exit code 1
-System Hardware (lshw -json || lshw) - Exit code 127
+ntp time (ntpdate -q pool.ntp.org || nc time.nist.gov 13 || netcat time.nist.gov 13) - OK
+ntp peers (ntpq -p) - Exit code 127
+raw /etc/sysconfig/clock (cat /etc/sysconfig/clock) - Exit code 1
+raw /etc/timezone (cat /etc/timezone) - OK
+System Hardware (lshw -json || lshw) - OK
+Process list snapshot (export TERM=''; top -Hb -n1 || top -H n1) - OK
 
 ...
 
-adding: /tmp/tmpMYbSyD/couchbase.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/couchbase.log
-adding: /tmp/tmpMYbSyD/ns_server.xdcr.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.xdcr.log
-adding: /tmp/tmpMYbSyD/ns_server.couchdb.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.couchdb.log
-adding: /tmp/tmpMYbSyD/stats.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/stats.log
-adding: /tmp/tmpMYbSyD/ini.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ini.log
-adding: /tmp/tmpMYbSyD/ns_server.error.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.error.log
-adding: /tmp/tmpMYbSyD/ns_server.ssl_proxy.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.ssl_proxy.log
-adding: /tmp/tmpMYbSyD/ns_server.views.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.views.log
-adding: /tmp/tmpMYbSyD/ns_server.info.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.info.log
-adding: /tmp/tmpMYbSyD/ns_server.xdcr_errors.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.xdcr_errors.log
-adding: /tmp/tmpMYbSyD/ns_server.mapreduce_errors.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.mapreduce_errors.log
-adding: /tmp/tmpMYbSyD/diag.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/diag.log
-adding: /tmp/tmpMYbSyD/ns_server.http_access.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.http_access.log
-adding: /tmp/tmpMYbSyD/syslog.tar.gz -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/syslog.tar.gz
-adding: /tmp/tmpMYbSyD/ns_server.debug.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.debug.log
-adding: /tmp/tmpMYbSyD/ddocs.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ddocs.log
-adding: /tmp/tmpMYbSyD/ns_server.reports.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.reports.log
-adding: /tmp/tmpMYbSyD/memcached.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/memcached.log
-adding: /tmp/tmpMYbSyD/ns_server.babysitter.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.babysitter.log
-adding: /tmp/tmpMYbSyD/ns_server.stats.log -> cbcollect_info_ns_1@10.5.2.117_20141209-024045/ns_server.stats.log
+adding: /tmp/tmpY7p_3T/couchbase.log -> cbcollect_info__20180718-084858/couchbase.log
+adding: /tmp/tmpY7p_3T/ns_server.error.log -> cbcollect_info__20180718-084858/ns_server.error.log
+adding: /tmp/tmpY7p_3T/ns_server.analytics_debug.log -> cbcollect_info__20180718-084858/ns_server.analytics_debug.log
+adding: /tmp/tmpY7p_3T/ns_server.json_rpc.log -> cbcollect_info__20180718-084858/ns_server.json_rpc.log
+adding: /tmp/tmpY7p_3T/cbcollect_info.log -> cbcollect_info__20180718-084858/cbcollect_info.log
+adding: /tmp/tmpY7p_3T/ns_server.ns_couchdb.log -> cbcollect_info__20180718-084858/ns_server.ns_couchdb.log
+adding: /tmp/tmpY7p_3T/ns_server.analytics.log -> cbcollect_info__20180718-084858/ns_server.analytics.log
+adding: /tmp/tmpY7p_3T/stats.log -> cbcollect_info__20180718-084858/stats.log
+adding: /tmp/tmpY7p_3T/memcached.log -> cbcollect_info__20180718-084858/memcached.log
+adding: /tmp/tmpY7p_3T/ns_server.indexer.log -> cbcollect_info__20180718-084858/ns_server.indexer.log
+adding: /tmp/tmpY7p_3T/ns_server.fts.log -> cbcollect_info__20180718-084858/ns_server.fts.log
+adding: /tmp/tmpY7p_3T/ns_server.http_access_internal.log -> cbcollect_info__20180718-084858/ns_server.http_access_internal.log
+adding: /tmp/tmpY7p_3T/ns_server.xdcr_target.log -> cbcollect_info__20180718-084858/ns_server.xdcr_target.log
+adding: /tmp/tmpY7p_3T/ns_server.eventing.log -> cbcollect_info__20180718-084858/ns_server.eventing.log
+adding: /tmp/tmpY7p_3T/syslog.tar.gz -> cbcollect_info__20180718-084858/syslog.tar.gz
+adding: /tmp/tmpY7p_3T/ns_server.reports.log -> cbcollect_info__20180718-084858/ns_server.reports.log
+adding: /tmp/tmpY7p_3T/ns_server.query.log -> cbcollect_info__20180718-084858/ns_server.query.log
+adding: /tmp/tmpY7p_3T/ns_server.couchdb.log -> cbcollect_info__20180718-084858/ns_server.couchdb.log
+adding: /tmp/tmpY7p_3T/ns_server.goxdcr.log -> cbcollect_info__20180718-084858/ns_server.goxdcr.log
+adding: /tmp/tmpY7p_3T/master_events.log -> cbcollect_info__20180718-084858/master_events.log
+adding: /tmp/tmpY7p_3T/ns_server.info.log -> cbcollect_info__20180718-084858/ns_server.info.log
+adding: /tmp/tmpY7p_3T/diag.log -> cbcollect_info__20180718-084858/diag.log
+adding: /tmp/tmpY7p_3T/ns_server.analytics_shutdown.log -> cbcollect_info__20180718-084858/ns_server.analytics_shutdown.log
+adding: /tmp/tmpY7p_3T/systemd_journal.gz -> cbcollect_info__20180718-084858/systemd_journal.gz
+adding: /tmp/tmpY7p_3T/ns_server.analytics_trace.json -> cbcollect_info__20180718-084858/ns_server.analytics_trace.json
+adding: /tmp/tmpY7p_3T/ns_server.stats.log -> cbcollect_info__20180718-084858/ns_server.stats.log
+adding: /tmp/tmpY7p_3T/ns_server.views.log -> cbcollect_info__20180718-084858/ns_server.views.log
+adding: /tmp/tmpY7p_3T/ini.log -> cbcollect_info__20180718-084858/ini.log
+adding: /tmp/tmpY7p_3T/kv_trace.json -> cbcollect_info__20180718-084858/kv_trace.json
+adding: /tmp/tmpY7p_3T/ns_server.mapreduce_errors.log -> cbcollect_info__20180718-084858/ns_server.mapreduce_errors.log
+adding: /tmp/tmpY7p_3T/ns_server.projector.log -> cbcollect_info__20180718-084858/ns_server.projector.log
+adding: /tmp/tmpY7p_3T/ns_server.metakv.log -> cbcollect_info__20180718-084858/ns_server.metakv.log
+adding: /tmp/tmpY7p_3T/ns_server.debug.log -> cbcollect_info__20180718-084858/ns_server.debug.log
+adding: /tmp/tmpY7p_3T/ns_server.babysitter.log -> cbcollect_info__20180718-084858/ns_server.babysitter.log
+adding: /tmp/tmpY7p_3T/ns_server.http_access.log -> cbcollect_info__20180718-084858/ns_server.http_access.log
 			</codeblock>
 			
 		</section>


### PR DESCRIPTION
* Add descriptions of new logs.

* Add new example output.

* Minor markup and punctuation changes.