### PR TITLE
DOC-2488: cbstats allocator wrong

### DIFF
--- a/content/cli/cbstats/cbstats-allocator.dita
+++ b/content/cli/cbstats/cbstats-allocator.dita
@@ -7,111 +7,135 @@
     <section>
       <title>Syntax</title>
       <p>Request syntax:</p>
-      <codeblock>cbstats [host]:11210 allocator</codeblock>
+      <codeblock>cbstats <varname>host</varname>:11210 [common options] allocator</codeblock>
     </section>
     <section><title>Description</title>
     <p>This command is used to collect information on memory management.</p>
     
     </section>
     <section><title>Options</title>
-      <p>None</p>
+      <p>There are no options for this command. For common <cmdname>cbstats</cmdname> options, see <xref href="../cbstats-intro.dita#cbstats-intro"/>.</p>
       
     </section>
     <section>
       <title>Examples</title>
-      <p>Example request:</p>
-      <codeblock>cbstats 10.5.2.54:11210 allocator</codeblock>
+      <p><b>Request</b></p>
+      <codeblock>cbstats localhost:11210 -u Administrator -p password -b beer-sample allocator</codeblock>
    
  
-      <p><b>Response:</b></p>
-      <codeblock>
-------------------------------------------------
-MALLOC:      211296632 (  201.5 MiB) Bytes in use by application
-MALLOC: +     11730944 (   11.2 MiB) Bytes in page heap freelist
-MALLOC: +     10833696 (   10.3 MiB) Bytes in central cache freelist
-MALLOC: +      3404400 (    3.2 MiB) Bytes in transfer cache freelist
-MALLOC: +     18832632 (   18.0 MiB) Bytes in thread cache freelists
-MALLOC: +      1781920 (    1.7 MiB) Bytes in malloc metadata
-MALLOC:   ------------
-MALLOC: =    257880224 (  245.9 MiB) Actual memory used (physical + swap)
-MALLOC: +      1236992 (    1.2 MiB) Bytes released to OS (aka unmapped)
-MALLOC:   ------------
-MALLOC: =    259117216 (  247.1 MiB) Virtual address space used
-MALLOC:
-MALLOC:           8855              Spans in use
-MALLOC:             16              Thread heaps in use
-MALLOC:           8192              Tcmalloc page size
-------------------------------------------------
-Call ReleaseFreeMemory() to release freelist memory to the OS (via madvise()).
-Bytes released to the OS take up virtual address space but no physical memory.
-------------------------------------------------
-Total size of freelists for per-thread caches,
-transfer cache, and central cache, by size class
-------------------------------------------------
-class   1 [        8 bytes ] :     7825 objs;   0.1 MiB;   0.1 cum MiB
-class   2 [       16 bytes ] :     1149 objs;   0.0 MiB;   0.1 cum MiB
-class   3 [       32 bytes ] :    47076 objs;   1.4 MiB;   1.5 cum MiB
-class   4 [       48 bytes ] :    51137 objs;   2.3 MiB;   3.9 cum MiB
-class   5 [       64 bytes ] :     3987 objs;   0.2 MiB;   4.1 cum MiB
-class   6 [       80 bytes ] :     5528 objs;   0.4 MiB;   4.5 cum MiB
-class   7 [       96 bytes ] :    18530 objs;   1.7 MiB;   6.2 cum MiB
-class   8 [      112 bytes ] :    39207 objs;   4.2 MiB;  10.4 cum MiB
-class   9 [      128 bytes ] :    25812 objs;   3.2 MiB;  13.6 cum MiB
-class  10 [      144 bytes ] :      399 objs;   0.1 MiB;  13.6 cum MiB
-class  11 [      160 bytes ] :      321 objs;   0.0 MiB;  13.7 cum MiB
-class  12 [      176 bytes ] :      201 objs;   0.0 MiB;  13.7 cum MiB
-class  13 [      192 bytes ] :      162 objs;   0.0 MiB;  13.7 cum MiB
-class  14 [      208 bytes ] :       70 objs;   0.0 MiB;  13.7 cum MiB
-class  15 [      224 bytes ] :       77 objs;   0.0 MiB;  13.8 cum MiB
-class  16 [      240 bytes ] :       72 objs;   0.0 MiB;  13.8 cum MiB
-class  17 [      256 bytes ] :       81 objs;   0.0 MiB;  13.8 cum MiB
-class  18 [      288 bytes ] :       38 objs;   0.0 MiB;  13.8 cum MiB
-class  19 [      320 bytes ] :       52 objs;   0.0 MiB;  13.8 cum MiB
-class  20 [      352 bytes ] :      112 objs;   0.0 MiB;  13.9 cum MiB
-class  21 [      384 bytes ] :       44 objs;   0.0 MiB;  13.9 cum MiB
-class  22 [      416 bytes ] :       18 objs;   0.0 MiB;  13.9 cum MiB
-class  23 [      448 bytes ] :       60 objs;   0.0 MiB;  13.9 cum MiB
-class  24 [      480 bytes ] :       77 objs;   0.0 MiB;  13.9 cum MiB
-class  25 [      512 bytes ] :     2726 objs;   1.3 MiB;  15.3 cum MiB
-class  26 [      576 bytes ] :      114 objs;   0.1 MiB;  15.3 cum MiB
-class  27 [      640 bytes ] :       84 objs;   0.1 MiB;  15.4 cum MiB
-class  28 [      704 bytes ] :       99 objs;   0.1 MiB;  15.4 cum MiB
-class  29 [      768 bytes ] :      125 objs;   0.1 MiB;  15.5 cum MiB
-class  30 [      832 bytes ] :      124 objs;   0.1 MiB;  15.6 cum MiB
-class  31 [      896 bytes ] :       43 objs;   0.0 MiB;  15.7 cum MiB
-class  32 [      960 bytes ] :       24 objs;   0.0 MiB;  15.7 cum MiB
-class  33 [     1024 bytes ] :       45 objs;   0.0 MiB;  15.7 cum MiB
-class  34 [     1152 bytes ] :       29 objs;   0.0 MiB;  15.8 cum MiB
-class  35 [     1280 bytes ] :       42 objs;   0.1 MiB;  15.8 cum MiB
-class  36 [     1408 bytes ] :       29 objs;   0.0 MiB;  15.9 cum MiB
-class  37 [     1536 bytes ] :       30 objs;   0.0 MiB;  15.9 cum MiB
-class  38 [     1792 bytes ] :      213 objs;   0.4 MiB;  16.3 cum MiB
-class  39 [     2048 bytes ] :      523 objs;   1.0 MiB;  17.3 cum MiB
-class  40 [     2304 bytes ] :       14 objs;   0.0 MiB;  17.3 cum MiB
-class  41 [     2560 bytes ] :        7 objs;   0.0 MiB;  17.3 cum MiB
-class  45 [     4096 bytes ] :       31 objs;   0.1 MiB;  17.5 cum MiB
-class  46 [     4608 bytes ] :        5 objs;   0.0 MiB;  17.5 cum MiB
-class  47 [     5120 bytes ] :        1 objs;   0.0 MiB;  17.5 cum MiB
-class  49 [     6656 bytes ] :        4 objs;   0.0 MiB;  17.5 cum MiB
-class  50 [     8192 bytes ] :       36 objs;   0.3 MiB;  17.8 cum MiB
-class  51 [     9216 bytes ] :       38 objs;   0.3 MiB;  18.1 cum MiB
-class  55 [    16384 bytes ] :       11 objs;   0.2 MiB;  18.3 cum MiB
-class  56 [    20480 bytes ] :        4 objs;   0.1 MiB;  18.4 cum MiB
-class  58 [    26624 bytes ] :        2 objs;   0.1 MiB;  18.4 cum MiB
-class  59 [    32768 bytes ] :        9 objs;   0.3 MiB;  18.7 cum MiB
-class  60 [    40960 bytes ] :        4 objs;   0.2 MiB;  18.9 cum MiB
-class  63 [    65536 bytes ] :        9 objs;   0.6 MiB;  19.4 cum MiB
-class  71 [   131072 bytes ] :        9 objs;   1.1 MiB;  20.6 cum MiB
-class  72 [   139264 bytes ] :        4 objs;   0.5 MiB;  21.1 cum MiB
-class  87 [   262144 bytes ] :        9 objs;   2.2 MiB;  23.3 cum MiB
-------------------------------------------------
-PageHeap: 3 sizes;   11.2 MiB free;    1.2 MiB unmapped
-------------------------------------------------
-     1 pages *     84 spans ~    0.7 MiB;    0.7 MiB cum; unmapped:    0.7 MiB;    0.7 MiB cum
-    14 pages *      1 spans ~    0.1 MiB;    0.8 MiB cum; unmapped:    0.1 MiB;    0.8 MiB cum
-    53 pages *      1 spans ~    0.4 MiB;    1.2 MiB cum; unmapped:    0.4 MiB;    1.2 MiB cum
->255   large *      1 spans ~   11.2 MiB;   12.4 MiB cum; unmapped:    0.0 MiB;    1.2 MiB cum
-   </codeblock>
+      <p><b>Response</b></p>
+      <codeblock>___ Begin jemalloc statistics ___
+Version: 4.5.0-3-g17c897976c60b0e6e4f4a365c751027244dada7a
+Assertions disabled
+config.malloc_conf: ""
+Run-time option settings:
+  opt.abort: false
+  opt.lg_chunk: 21
+  opt.dss: "secondary"
+  opt.narenas: 1
+  opt.purge: "ratio"
+  opt.lg_dirty_mult: 3 (arenas.lg_dirty_mult: 3)
+  opt.junk: "false"
+  opt.quarantine: 0
+  opt.redzone: false
+  opt.zero: false
+  opt.tcache: true
+  opt.lg_tcache_max: 15
+  opt.thp: true
+  opt.prof: true
+  opt.prof_prefix: "jeprof"
+  opt.prof_active: false (prof.active: false)
+  opt.prof_thread_active_init: true (prof.thread_active_init: true)
+  opt.lg_prof_sample: 19 (prof.lg_sample: 19)
+  opt.prof_accum: false
+  opt.lg_prof_interval: -1
+  opt.prof_gdump: false
+  opt.prof_final: false
+  opt.prof_leak: false
+  opt.stats_print: false
+Arenas: 1
+Min active:dirty page ratio per arena: 8:1
+Quantum size: 16
+Page size: 4096
+Maximum thread-cached size class: 32768
+Allocated: 346524744, active: 347295744, metadata: 3015888, resident: 349773824, mapped: 352321536, retained: 0
+Current active ceiling: 348127232
+
+Merged arenas stats:
+assigned threads: 26
+dss allocation precedence: N/A
+min active:dirty page ratio: N/A
+purging: dirty: 55, sweeps: 22, madvises: 103, purged: 734
+                            allocated      nmalloc      ndalloc    nrequests
+small:                       54406216       371163        97660      3572656
+large:                        2711552          800          731         1113
+huge:                       289406976            2            0            2
+total:                      346524744       371965        98391      3573771
+active:                     347295744
+mapped:                     350224384
+retained:                           0
+metadata: mapped: 1544192, allocated: 764112
+bins:           size ind    allocated      nmalloc      ndalloc    nrequests      curregs      curruns regs pgs  util       nfills     nflushes      newruns       reruns
+                   8   0        24920        11111         7996       249538         3115            8  512   1 0.760          268          225           11           42
+                  16   1       172144        16287         5528       165964        10759           45  256   1 0.933          854          262           52           73
+                  32   2      2718176        94573         9630      1065895        84943          666  128   1 0.996         2687          370          680          912
+                  48   3      1189920        31571         6781       602628        24790           99  256   3 0.978          534          264          112          159
+                  64   4      1049984        55777        39371       695278        16406          260   64   1 0.985        17213          798          685          456
+                  80   5      3011280        40424         2783       123762        37641          149  256   5 0.986          664          180          150           92
+                  96   6       460704         9162         4363        50856         4799           40  128   3 0.937          748          145           51           90
+                 112   7      2890608        29796         3987       212934        25809          101  256   7 0.998          771          249          113           94
+                 128   8       118016         2300         1378        31350          922           34   32   1 0.847          188          190           43          125
+                 160   9      1146240         8407         1243        57356         7164           58  128   5 0.964          822          122           59           49
+                 192  10       713856         7276         3558        10311         3718           65   64   3 0.893          305          179           68          265
+                 224  11       847392         6053         2270         8692         3783           31  128   7 0.953          139          130           35           78
+                 256  12       356096         1984          593        54486         1391           89   16   1 0.976          215          163           95          108
+                 320  13      1066560         5149         1816        24729         3333           54   64   5 0.964          239          148           61           62
+                 384  14      1202304         3680          549         6044         3131           99   32   3 0.988          261           90          104           49
+                 448  15       977088         3072          891         6756         2181           35   64   7 0.973          125           95           40           52
+                 512  16      6400512        12868          367        28954        12501         1567    8   1 0.997         1871          137         1579          145
+                 640  17     11372160        18594          825        83906        17769          559   32   5 0.993         1389          109          566           48
+                 768  18      1431552         2058          194        12499         1864          117   16   3 0.995          200           55          126           27
+                 896  19       727552         1294          482         3584          812           27   32   7 0.939          100           99           32           55
+                1024  20       389120          761          381         1568          380           95    4   1 1              156          159          152          123
+                1280  21       627200          765          275         1120          490           32   16   5 0.957           92           87           43           56
+                1536  22      3457536         2395          144         6091         2251          283    8   3 0.994          339           70          289           59
+                1792  23        94976          195          142          464           53            4   16   7 0.828           38           68            8           14
+                2048  24      4489216         2522          330         2888         2192         1096    2   1 1              392          139         1210          129
+                2560  25       227840          182           93          179           89           12    8   5 0.927           34           53           18           27
+                3072  26       279552          217          126          232           91           24    4   3 0.947           35           61           42           45
+                3584  27       297472          173           90          216           83           11    8   7 0.943           32           54           17           26
+                4096  28      1335296         1090          764        62772          326          326    1   1 1              244          175         1090            0
+                5120  29       916480          298          119          440          179           45    4   5 0.994           42           59           61           59
+                6144  30       946176          298          144          402          154           79    2   3 0.974           55           74          137           50
+                7168  31       609280          191          106          233           85           23    4   7 0.923           35           61           37           57
+                8192  32      1368064          299          132          301          167          167    1   2 1              114           82          299            0
+               10240  33       839680          161           79          138           82           41    2   5 1               33           57           69           36
+               12288  34       393216          114           82           50           32           32    1   3 1               17           47          114            0
+               14336  35       258048           66           48           40           18            9    2   7 1                9           38           32            4
+large:          size ind    allocated      nmalloc      ndalloc    nrequests      curruns
+               16384  36       180224           95           84          134           11
+               20480  37       143360           11            4           46            7
+               24576  38       122880            8            3           48            5
+               28672  39       774144           54           27           86           27
+               32768  40       196608           83           77          250            6
+               40960  41        81920           42           40           42            2
+               49152  42            0           76           76           76            0
+               57344  43       458752          104           96          104            8
+               65536  44            0          306          306          306            0
+               81920  45            0           16           16           16            0
+               98304  46        98304            1            0            1            1
+                     ---
+              131072  48       131072            3            2            3            1
+                     ---
+              524288  56       524288            1            0            1            1
+                     ---
+huge:           size ind    allocated      nmalloc      ndalloc    nrequests   curhchunks
+                     ---
+            20971520  77     20971520            1            0            1            1
+                     ---
+           268435456  92    268435456            1            0            1            1
+                     ---
+--- End jemalloc statistics ---</codeblock>
     </section>
   </refbody>
 </reference>


### PR DESCRIPTION
Update example with jemalloc output.
Bring synopsis in line with other cbstats help.