### PR TITLE
Updates to latest community server version

### DIFF
--- a/content/install/ubuntu-debian-install.dita
+++ b/content/install/ubuntu-debian-install.dita
@@ -12,11 +12,11 @@
     <p>On modern versions of Debian (Debian 8+) and Ubuntu (Ubuntu 14.04+), the "apt" command
       simplifies the installation greatly. </p><ol>
       <li>Download and install the appropriate meta package from the <xref
-          href="https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-4-amd64.deb"
+          href="https://packages.couchbase.com/releases/5.1.1/couchbase-server-community_5.1.1-debian9_amd64.deb"
           format="html" scope="external">package download location</xref>. This will install the
         package source and the Couchbase public
-        keys:<codeblock outputclass="language-bash">curl -O http://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-4-amd64.deb   
-sudo dpkg -i couchbase-release-1.0-4-amd64.deb</codeblock></li>
+        keys:<codeblock outputclass="language-bash">curl -O https://packages.couchbase.com/releases/5.1.1/couchbase-server-community_5.1.1-debian9_amd64.deb   
+sudo dpkg -i couchbase-server-community_5.1.1-debian9_amd64.deb</codeblock></li>
     <li>Run the following commands to automatically download and install Couchbase along with the
         appropriate <codeph>libssl</codeph> and Python dependencies.
           <codeblock>apt-get update


### PR DESCRIPTION
Updates the download link and the code instructions to download and install couchbase-server-community_5.1.1-debian9_amd64.deb