### PR TITLE
Point out the port for the eventing REST API.

### DIFF
--- a/content/eventing/eventing-api.dita
+++ b/content/eventing/eventing-api.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="eventing_api">
   <title> Functions REST API </title>
-  <shortdesc> The Functions REST API provides the methods available to work with Couchbase
+  <shortdesc> The Functions REST API, available by default at port 8096, provides the methods available to work with Couchbase
     Functions. </shortdesc>
   <body>
     <section id="section_kzm_vyy_m2b">
@@ -81,7 +81,7 @@
                     reference.</p>
                   <p dir="ltr">Sample API:
                     <codeblock>curl -XPOST -d '{"deployment_status":true,"processing_status":true}' 
-http://Administrator@192.168.1.5:8091/api/v1/functions/[sample_name]/settings</codeblock>
+http://Administrator@192.168.1.5:8096/api/v1/functions/[sample_name]/settings</codeblock>
                   </p>
                 </entry>
               </row>
@@ -94,7 +94,7 @@ http://Administrator@192.168.1.5:8091/api/v1/functions/[sample_name]/settings</c
                     reference.</p>
                   <p dir="ltr">Sample API:
                     <codeblock>curl -XPOST -d '{"deployment_status":false,"processing_status":false}' 
-http://Administrator@192.168.1.5:8091/api/v1/functions/[sample_name]/settings</codeblock></p>
+http://Administrator@192.168.1.5:8096/api/v1/functions/[sample_name]/settings</codeblock></p>
                 </entry>
               </row>
               <row>


### PR DESCRIPTION
Corrects the port for the eventing REST API (it's not at port 8091 but at 8096).