### PR TITLE
patch syntax errors in DITA sources (5.1)

### DIFF
--- a/content/cli/cbstats/cbstats-uuid.dita
+++ b/content/cli/cbstats/cbstats-uuid.dita
@@ -20,7 +20,7 @@
      
       <table>
        
-        <tgroup cols="3">
+        <tgroup cols="2">
           <colspec colname="col1" colwidth="1*"/>
           <colspec colname="col2" colwidth="3*"/>
           <thead>

--- a/content/cli/cbstats/cbstats-workload.dita
+++ b/content/cli/cbstats/cbstats-workload.dita
@@ -18,7 +18,7 @@
       <p>	The following are the command options:</p>
       <table>
         <title>workload options</title>
-        <tgroup cols="3">
+        <tgroup cols="2">
           <colspec colname="col1" colwidth="1*"/>
           <colspec colname="col2" colwidth="3*"/>
           <thead>

--- a/content/release-notes/relnotes-v5.0.x.dita
+++ b/content/release-notes/relnotes-v5.0.x.dita
@@ -114,7 +114,7 @@
               >DCP</xref>).</li>
           <li>Starting 5.0, port based buckets can only be created now through the bucket CLI
             command. Use the <xref
-              href="../cli/cbcli/couchbase-cli-bucket-create.dita#couchbaseclibucketcreate1.idm386415259904"
+              href="../cli/cbcli/couchbase-cli-bucket-create.dita"
             /> command to create a port based bucket. <note type="remember">Server-side moxi which
               drives port based bucket creation has been deprecated. Consider using client-side moxi
               instead.</note></li>

--- a/content/security/concepts-rba.dita
+++ b/content/security/concepts-rba.dita
@@ -14,8 +14,7 @@
 
    <p>Full administrators in Couchbase can manage user roles using the Couchbase CLI tools (as
       described in <xref
-        href="../cli/cbcli/couchbase-cli-admin-role-manage.dita#couchbasecliadminrolemanage1.idm31783028880"
-        />) or REST API (as described in
+        href="../cli/cbcli/couchbase-cli-admin-role-manage.dita"/>) or REST API (as described in
         <xref href="../rest-api/rbac.dita#topic_d3q_mt3_fw"/>).</p>
 
    <section>


### PR DESCRIPTION
* use correct number of columns in cols attribute on table
* fix xref targets