### PR TITLE
patch syntax errors in DITA sources (5.5)

### DIFF
--- a/content/cli/cbstats/cbstats-uuid.dita
+++ b/content/cli/cbstats/cbstats-uuid.dita
@@ -20,7 +20,7 @@
      
       <table>
        
-        <tgroup cols="3">
+        <tgroup cols="2">
           <colspec colname="col1" colwidth="1*"/>
           <colspec colname="col2" colwidth="3*"/>
           <thead>

--- a/content/cli/cbstats/cbstats-workload.dita
+++ b/content/cli/cbstats/cbstats-workload.dita
@@ -18,7 +18,7 @@
       <p>	The following are the command options:</p>
       <table>
         <title>workload options</title>
-        <tgroup cols="3">
+        <tgroup cols="2">
           <colspec colname="col1" colwidth="1*"/>
           <colspec colname="col2" colwidth="3*"/>
           <thead>

--- a/content/install/install-production-deployment.dita
+++ b/content/install/install-production-deployment.dita
@@ -82,10 +82,8 @@
 				</tbody>
 			</tgroup>
 		</table>
-	</conbody>
-	<concept id="concept_tyg_y3s_42b">
-		<title>General Guidelines</title>
-		<conbody>
+		<section>
+			<title>General Guidelines</title>
 			<dl>
 				<dlentry>
 					<dt>Use RAID 1+0 (or RAID 1) if Couchbase bucket replication is 1 or lower</dt>
@@ -119,28 +117,26 @@
 					<dd>For Windows OS, use 64k allocation sizes on NTFS file systems.</dd>
 				</dlentry>
 			</dl>
-		</conbody>
-		<concept id="concept_yd5_fjs_42b">
+		</section>
+		<section>
 			<title>Nodes Running the Data Service</title>
-			<conbody>
-				<dl>
-					<dlentry>
-						<dt>Isolate the data and indexes</dt>
-						<dd>For the best performance, isolate the data and indexes (note that these
-							are different from the Index Service) at the physical disk level. </dd>
-					</dlentry>
-				</dl>
-				<dl>
-					<dlentry>
-						<dt>Combine different workloads</dt>
-						<dd>Combining different workloads (workloads with very different I/O and
-							latency characteristics) can have a negative effect on the overall
-							performance. In case of combined workloads, it might be appropriate to
-							have objects in different buckets and the files for each bucket on
-							different mount points/paths.</dd>
-					</dlentry>
-				</dl>
-			</conbody>
-		</concept>
-	</concept>
+			<dl>
+				<dlentry>
+					<dt>Isolate the data and indexes</dt>
+					<dd>For the best performance, isolate the data and indexes (note that these
+						are different from the Index Service) at the physical disk level. </dd>
+				</dlentry>
+			</dl>
+			<dl>
+				<dlentry>
+					<dt>Combine different workloads</dt>
+					<dd>Combining different workloads (workloads with very different I/O and
+						latency characteristics) can have a negative effect on the overall
+						performance. In case of combined workloads, it might be appropriate to
+						have objects in different buckets and the files for each bucket on
+						different mount points/paths.</dd>
+				</dlentry>
+			</dl>
+		</section>
+	</conbody>
 </concept>


### PR DESCRIPTION
* use correct number of columns in cols attribute on table
* replace nested concept elements with section elements