### PR TITLE
Update DNS SRV example to include port

### DIFF
--- a/content/sdk/shared/dnssrv-pars.dita
+++ b/content/sdk/shared/dnssrv-pars.dita
@@ -15,15 +15,15 @@
                 <li>Enable it on the SDK and point it towards the DNS SRV entry.</li>
             </ol>
             <p>Your DNS server should be set up like this (one row for each bootstrap node):</p>
-            <codeblock><![CDATA[_couchbase._tcp.example.com.  3600  IN  SRV  0  0  0  node1.example.com.
-_couchbase._tcp.example.com.  3600  IN  SRV  0  0  0  node2.example.com.
-_couchbase._tcp.example.com.  3600  IN  SRV  0  0  0  node3.example.com.]]></codeblock>
-            <p><note>The ordering, priorities, ports and weighting are completely ignored and should
+            <codeblock><![CDATA[_couchbase._tcp.example.com.  3600  IN  SRV  0  0  11210  node1.example.com.
+_couchbase._tcp.example.com.  3600  IN  SRV  0  0  11210  node2.example.com.
+_couchbase._tcp.example.com.  3600  IN  SRV  0  0  11210  node3.example.com.]]></codeblock>
+            <p><note>The ordering, priorities and weighting are completely ignored and should
                     not be set on the records to avoid ambiguities.</note>If you plan to use secure
                 connections, you use <codeph>_couchbases</codeph> instead: </p>
-            <codeblock><![CDATA[_couchbases._tcp.example.com.  3600  IN  SRV  0  0  0  node1.example.com.
-_couchbases._tcp.example.com.  3600  IN  SRV  0  0  0  node2.example.com.
-_couchbases._tcp.example.com.  3600  IN  SRV  0  0  0  node3.example.com.]]> </codeblock>
+            <codeblock><![CDATA[_couchbases._tcp.example.com.  3600  IN  SRV  0  0  11207  node1.example.com.
+_couchbases._tcp.example.com.  3600  IN  SRV  0  0  11207  node2.example.com.
+_couchbases._tcp.example.com.  3600  IN  SRV  0  0  11207  node3.example.com.]]> </codeblock>
         </section>
   </body>
 </topic>


### PR DESCRIPTION
I tried to use a DNS SRV record with both the python and nodejs SDK. Each time the bootstrapping failed. It was then recommended that I use a port instead of port 0 https://github.com/brantburnett/terraform-aws-autoscaling-route53-srv/issues/2 . I also opened an issue in the forum https://forums.couchbase.com/t/couchbase-5-5-error-when-trying-dns-srv/20292. 

The java SDK also has its own set of docs https://github.com/couchbase/docs-cb4/blob/257453111f4867a5d31a815c9ca8ebf5ffa8f751/content/sdk/java/managing-connections.dita but I'm not sure they are affected. 

I was using RHEL7 on AWS Ec2 and R53. 